### PR TITLE
MODQM-16 - Incorrect saved record fields order

### DIFF
--- a/src/main/java/org/folio/converter/QuickMarcToParsedRecordConverter.java
+++ b/src/main/java/org/folio/converter/QuickMarcToParsedRecordConverter.java
@@ -90,7 +90,7 @@ public class QuickMarcToParsedRecordConverter implements Converter<QuickMarcJson
   }
 
   private String retrieveIndicatorValue(Object input) {
-    return Objects.isNull(input) ? " " : input.toString();
+    return Objects.isNull(input) || StringUtils.isEmpty(input.toString()) ? SPACE : input.toString();
   }
 
   private String restoreControlFieldContent(String tag, Object content) {

--- a/src/test/java/org/folio/converter/TestUtils.java
+++ b/src/test/java/org/folio/converter/TestUtils.java
@@ -5,13 +5,19 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.IOUtils;
+import org.folio.rest.jaxrs.model.Field;
+import org.folio.rest.jaxrs.model.QuickMarcJson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.vertx.core.json.JsonObject;
+
+import static org.folio.converter.QuickMarcToParsedRecordConverterTest.TESTED_TAG_NAME;
 
 public class TestUtils {
   private static final Logger logger = LoggerFactory.getLogger(TestUtils.class);
@@ -39,5 +45,18 @@ public class TestUtils {
         return sb.toString();
       }
     }
+  }
+
+  public static Field getFieldWithIndicators(List<Object> indicators) {
+    return new Field()
+      .withTag(TESTED_TAG_NAME)
+      .withContent("$333 content")
+      .withIndicators(indicators);
+  }
+
+  public static QuickMarcJson getQuickMarcJsonWithMinContent(Field... fields) {
+    return new QuickMarcJson()
+      .withLeader("01542ccm a2200361   4500")
+      .withFields(Arrays.asList(fields));
   }
 }


### PR DESCRIPTION
Follow-up commit to [#24](https://github.com/folio-org/mod-quick-marc/pull/24) to caver particular case with indicators ["", ""].