### PR TITLE
MODQM-19 - quickMARC response status to 202 on record update

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,6 @@ quickMARC API provides the following URLs:
 
 More detail can be found on quickMARC wiki-page: [WIKI quickMARC](https://wiki.folio.org/pages/viewpage.action?pageId=36571766).
 
-It should be noted that quickMARC never returns error 404 (NOT FOUND) for SRS record updating even though record doesn't exist 
-due to specific of [Change Manager](https://s3.amazonaws.com/foliodocs/api/mod-source-record-manager/p/change-manager.html#change_manager_parsedrecords__id__put).
-
 ### Required Permissions
 Institutional users should be granted the following permissions in order to use this quickMARC API:
 - `records-editor.all`

--- a/ramls/records-editor.raml
+++ b/ramls/records-editor.raml
@@ -79,14 +79,8 @@ traits:
             strict: false
             value: sample
       responses:
-        204:
-          description: "MARC record successfully updated"
-          body:
-            application/json:
-              type: quickMarcJson
-              example:
-                strict: false
-                value: sample
+        202:
+          description: "MARC record accepted for updating"
         400:
           description: "Bad request, e.g. malformed request body or query parameter. Details of the error (e.g. name of the parameter or line/character number with malformed data) provided in the response."
           body:

--- a/src/main/java/org/folio/converter/QuickMarcToParsedRecordDtoConverter.java
+++ b/src/main/java/org/folio/converter/QuickMarcToParsedRecordDtoConverter.java
@@ -152,7 +152,7 @@ public class QuickMarcToParsedRecordDtoConverter implements Converter<QuickMarcJ
       !contentMap.get(DESC).toString().equals(Character.toString(leaderField.getImplDefined2()[1]))) {
       throw new ConverterException(buildError(ErrorUtils.ErrorType.INTERNAL,"The Leader and 008 do not match"));
     }
-    leaderField.setImplDefined2(new char[]{contentMap.get(ELVL).toString().charAt(0), contentMap.get(DESC).toString().charAt(0), SPACE_CHARACTER});
+    leaderField.setImplDefined2(new char[]{contentMap.get(ELVL).toString().charAt(0), contentMap.get(DESC).toString().charAt(0), leaderField.getImplDefined2()[2]});
     String specificItemsString = restoreFixedLengthField(ADDITIONAL_CHARACTERISTICS_CONTROL_FIELD_LENGTH, materialTypeConfiguration.getFixedLengthControlFieldItems(), contentMap);
     return new StringBuilder(restoreFixedLengthField(GENERAL_INFORMATION_CONTROL_FIELD_LENGTH, MaterialTypeConfiguration.getCommonItems(), contentMap))
       .replace(SPECIFIC_ELEMENTS_BEGIN_INDEX, SPECIFIC_ELEMENTS_END_INDEX, specificItemsString).toString();

--- a/src/main/java/org/folio/rest/impl/RecordsEditorRecordsApi.java
+++ b/src/main/java/org/folio/rest/impl/RecordsEditorRecordsApi.java
@@ -49,7 +49,7 @@ public class RecordsEditorRecordsApi implements RecordsEditorRecords {
   public void putRecordsEditorRecordsById(String parsedRecordId, QuickMarcJson entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     if (parsedRecordId.equals(entity.getParsedRecordId())) {
       service.putMarcRecordById(entity.getParsedRecordDtoId(), entity, vertxContext, okapiHeaders)
-        .thenAccept(vVoid -> asyncResultHandler.handle(succeededFuture(Response.noContent().build())))
+        .thenAccept(vVoid -> asyncResultHandler.handle(succeededFuture(Response.accepted().build())))
         .exceptionally(throwable -> handleErrorResponse(asyncResultHandler, throwable));
     } else {
       asyncResultHandler.handle(succeededFuture(PutRecordsEditorRecordsByIdResponse.respond400WithApplicationJson(buildError(400, ErrorUtils.ErrorType.INTERNAL, "request id and entity id are not equal"))));

--- a/src/test/java/org/folio/rest/impl/QuickMarcApiTest.java
+++ b/src/test/java/org/folio/rest/impl/QuickMarcApiTest.java
@@ -129,13 +129,13 @@ public class QuickMarcApiTest extends ApiTestBase {
 
     wireMockServer.stubFor(put(urlEqualTo(getResourceByIdPath(CM_RECORDS, VALID_PARSED_RECORD_DTO_ID)))
       .withRequestBody(containing(getJsonObject(PARSED_RECORD_DTO_PATH).encode()))
-      .willReturn(aResponse().withStatus(204)));
+      .willReturn(aResponse().withStatus(202)));
 
     QuickMarcJson quickMarcJson = getJsonObject(QUICK_MARC_RECORD_PATH).mapTo(QuickMarcJson.class)
       .withParsedRecordDtoId(VALID_PARSED_RECORD_DTO_ID)
       .withInstanceId(EXISTED_INSTANCE_ID);
 
-    verifyPutRequest(String.format(RECORDS_EDITOR_RECORDS_PATH_ID, VALID_PARSED_RECORD_ID), quickMarcJson, 204);
+    verifyPutRequest(String.format(RECORDS_EDITOR_RECORDS_PATH_ID, VALID_PARSED_RECORD_ID), quickMarcJson, 202);
 
     assertThat(wireMockServer.getAllServeEvents(), hasSize(1));
     ParsedRecordDto changeManagerRequest = new JsonObject(wireMockServer.getAllServeEvents()


### PR DESCRIPTION
[MODQM-19](https://issues.folio.org/browse/MODQM-19) - quickMARC response status to 202 on record update

## Purpose
QuickMARC PUT /records-editor/records/{id} endpoint should return 202 status upon receiving the request

## Approach
Changing of rail-contract, unit tests updating

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
