### PR TITLE
MODQM-20 - quickMARC: ParsedRecordDto -> QuickMarcJson error handling

### DIFF
--- a/src/main/java/org/folio/converter/ParsedRecordDtoToQuickMarcConverter.java
+++ b/src/main/java/org/folio/converter/ParsedRecordDtoToQuickMarcConverter.java
@@ -14,9 +14,7 @@ import static org.folio.converter.Constants.PHYSICAL_DESCRIPTIONS_CONTROL_FIELD;
 import static org.folio.converter.Constants.SPECIFIC_ELEMENTS_BEGIN_INDEX;
 import static org.folio.converter.Constants.SPECIFIC_ELEMENTS_END_INDEX;
 import static org.folio.converter.Constants.TYPE;
-import static org.folio.util.ErrorUtils.buildError;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -35,7 +33,6 @@ import org.folio.rest.jaxrs.model.Field;
 import org.folio.rest.jaxrs.model.QuickMarcJson;
 import org.folio.srs.model.ParsedRecord;
 import org.folio.srs.model.ParsedRecordDto;
-import org.folio.util.ErrorUtils;
 import org.marc4j.MarcJsonReader;
 import org.marc4j.marc.ControlField;
 import org.marc4j.marc.DataField;
@@ -75,8 +72,8 @@ public class ParsedRecordDtoToQuickMarcConverter implements Converter<ParsedReco
         .withParsedRecordDtoId(parsedRecordDto.getId())
         .withInstanceId(parsedRecordDto.getExternalIdsHolder().getInstanceId())
         .withSuppressDiscovery(parsedRecordDto.getAdditionalInfo().getSuppressDiscovery());
-    } catch (IOException e) {
-      throw new ConverterException(buildError(ErrorUtils.ErrorType.INTERNAL,"Generic converter error"));
+    } catch (Exception e) {
+      throw new ConverterException(e, this.getClass());
     }
   }
 

--- a/src/main/java/org/folio/converter/QuickMarcToParsedRecordDtoConverter.java
+++ b/src/main/java/org/folio/converter/QuickMarcToParsedRecordDtoConverter.java
@@ -71,19 +71,24 @@ public class QuickMarcToParsedRecordDtoConverter implements Converter<QuickMarcJ
 
   @Override
   public ParsedRecordDto convert(QuickMarcJson quickMarcJson) {
-    Record marcRecord = quickMarcJsonToMarcRecord(quickMarcJson);
+    try {
+      Record marcRecord = quickMarcJsonToMarcRecord(quickMarcJson);
 
-    Map<String, Object> contentMap = new LinkedHashMap<>();
-    contentMap.put(FIELDS, convertMarcFieldsToObjects(marcRecord));
-    contentMap.put(LEADER, marcRecord.getLeader()
-      .marshal());
+      Map<String, Object> contentMap = new LinkedHashMap<>();
+      contentMap.put(FIELDS, convertMarcFieldsToObjects(marcRecord));
+      contentMap.put(LEADER, marcRecord.getLeader()
+        .marshal());
 
-    return new ParsedRecordDto().withParsedRecord(new ParsedRecord().withId(quickMarcJson.getParsedRecordId())
-      .withContent(contentMap))
-      .withRecordType(ParsedRecordDto.RecordType.MARC)
-      .withId(quickMarcJson.getParsedRecordDtoId())
-      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(quickMarcJson.getInstanceId()))
-      .withAdditionalInfo(new AdditionalInfo().withSuppressDiscovery(quickMarcJson.getSuppressDiscovery()));
+      return new ParsedRecordDto().withParsedRecord(new ParsedRecord().withId(quickMarcJson.getParsedRecordId())
+        .withContent(contentMap))
+        .withRecordType(ParsedRecordDto.RecordType.MARC)
+        .withId(quickMarcJson.getParsedRecordDtoId())
+        .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(quickMarcJson.getInstanceId()))
+        .withAdditionalInfo(new AdditionalInfo().withSuppressDiscovery(quickMarcJson.getSuppressDiscovery()));
+
+    } catch (Exception e) {
+      throw new ConverterException(e, this.getClass());
+    }
   }
 
   private Record quickMarcJsonToMarcRecord(QuickMarcJson quickMarcJson) {

--- a/src/main/java/org/folio/exception/ConverterException.java
+++ b/src/main/java/org/folio/exception/ConverterException.java
@@ -3,8 +3,9 @@ package org.folio.exception;
 import io.vertx.core.json.JsonObject;
 import org.folio.HttpStatus;
 import org.folio.rest.jaxrs.model.Error;
+import org.folio.util.ErrorUtils;
 
-import static org.apache.commons.lang3.math.NumberUtils.toInt;
+import static org.folio.util.ErrorUtils.buildError;
 
 /**
  * Custom exception for QuickMarcJson <-> ParsedRecordDto converting errors
@@ -19,6 +20,17 @@ public class ConverterException extends RuntimeException {
   public ConverterException(Error error) {
     code = HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt();
     errorJson = JsonObject.mapFrom(error);
+  }
+
+  public ConverterException(Exception ex, Class<?> clazz) {
+    if (ex instanceof ConverterException) {
+      ConverterException cex = (ConverterException) ex;
+      errorJson = cex.getError();
+      code = cex.getCode();
+    } else {
+      errorJson = JsonObject.mapFrom(buildError(ErrorUtils.ErrorType.INTERNAL,clazz.getSimpleName() + ": Generic Error"));
+      code = HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt();
+    }
   }
 
   public JsonObject getError() {

--- a/src/test/java/org/folio/rest/impl/QuickMarcApiTest.java
+++ b/src/test/java/org/folio/rest/impl/QuickMarcApiTest.java
@@ -53,8 +53,7 @@ public class QuickMarcApiTest extends ApiTestBase {
         .withHeader(CONTENT_TYPE, APPLICATION_JSON)
         .withStatus(200)));
 
-    QuickMarcJson quickMarcJson = verifyGetRequest(RECORDS_EDITOR_RECORDS_PATH + buildQuery(INSTANCE_ID, EXISTED_INSTANCE_ID), 200)
-      .as(QuickMarcJson.class);
+    QuickMarcJson quickMarcJson = verifyGetRequest(RECORDS_EDITOR_RECORDS_PATH + buildQuery(INSTANCE_ID, EXISTED_INSTANCE_ID), 200).as(QuickMarcJson.class);
 
     assertThat(quickMarcJson.getParsedRecordDtoId(), equalTo(VALID_PARSED_RECORD_DTO_ID));
     assertThat(quickMarcJson.getInstanceId(), equalTo(EXISTED_INSTANCE_ID));
@@ -74,26 +73,23 @@ public class QuickMarcApiTest extends ApiTestBase {
   void testGetQuickMarcRecordNotFound() {
     logger.info("===== Verify GET record: Record Not Found =====");
 
-    String recordNotFoundId = UUID.randomUUID()
-      .toString();
+    String recordNotFoundId = UUID.randomUUID().toString();
 
     wireMockServer
       .stubFor(get(urlEqualTo(getResourcesPath(CM_RECORDS) + buildQuery(INSTANCE_ID, recordNotFoundId))).willReturn(aResponse()
-        .withBody(JsonObject.mapFrom(new Error())
-          .encode())
+        .withBody(JsonObject.mapFrom(new Error()).encode())
         .withHeader(CONTENT_TYPE, APPLICATION_JSON)
         .withStatus(HttpStatus.HTTP_NOT_FOUND.toInt())));
 
-    Error error = verifyGetRequest(RECORDS_EDITOR_RECORDS_PATH + buildQuery(INSTANCE_ID, recordNotFoundId),
-        HttpStatus.HTTP_NOT_FOUND.toInt()).as(Error.class);
-    assertThat(error.getType(), equalTo(ErrorUtils.ErrorType.FOLIO_EXTERNAL_OR_UNDEFINED.getTypeCode()));
+    Error error = verifyGetRequest(RECORDS_EDITOR_RECORDS_PATH + buildQuery(INSTANCE_ID, recordNotFoundId), HttpStatus.HTTP_NOT_FOUND.toInt()).as(Error.class);
 
+    assertThat(error.getType(), equalTo(ErrorUtils.ErrorType.FOLIO_EXTERNAL_OR_UNDEFINED.getTypeCode()));
     assertThat(wireMockServer.getAllServeEvents(), hasSize(1));
   }
 
   @Test
-  void testGetQuickMarcRecordInternalServerError() {
-    logger.info("===== Verify GET record: Internal Server Error (quickMARC internal exception) =====");
+  void testGetQuickMarcRecordConverterError() {
+    logger.info("===== Verify GET record: Converter (quickMARC internal exception) =====");
 
     String internalServerErrorInstanceId = UUID.randomUUID()
       .toString();
@@ -103,8 +99,7 @@ public class QuickMarcApiTest extends ApiTestBase {
         .withHeader(CONTENT_TYPE, APPLICATION_JSON)
         .withStatus(200)));
 
-    Error error = verifyGetRequest(RECORDS_EDITOR_RECORDS_PATH + buildQuery(INSTANCE_ID, internalServerErrorInstanceId), 500)
-      .as(Error.class);
+    Error error = verifyGetRequest(RECORDS_EDITOR_RECORDS_PATH + buildQuery(INSTANCE_ID, internalServerErrorInstanceId), 422).as(Error.class);
     assertThat(error.getType(), equalTo(ErrorUtils.ErrorType.INTERNAL.getTypeCode()));
 
     assertThat(wireMockServer.getAllServeEvents(), hasSize(1));
@@ -114,8 +109,7 @@ public class QuickMarcApiTest extends ApiTestBase {
   void testGetQuickMarcRecordWithoutInstanceIdParameter() {
     logger.info("===== Verify GET record: Request without instanceId =====");
 
-    String id = UUID.randomUUID()
-      .toString();
+    String id = UUID.randomUUID().toString();
 
     Error error = verifyGetRequest(RECORDS_EDITOR_RECORDS_PATH + buildQuery("X", id), 400).as(Error.class);
     assertThat(error.getType(), equalTo(ErrorUtils.ErrorType.INTERNAL.getTypeCode()));
@@ -148,12 +142,10 @@ public class QuickMarcApiTest extends ApiTestBase {
   @Test
   void testUpdateQuickMarcRecordWrongUuid() {
     logger.info("===== Verify PUT record: Not found =====");
-    String wrongUUID = UUID.randomUUID()
-      .toString();
+    String wrongUUID = UUID.randomUUID().toString();
 
     wireMockServer.stubFor(put(urlEqualTo(getResourceByIdPath(CM_RECORDS, wrongUUID))).willReturn(aResponse()
-      .withBody(JsonObject.mapFrom(new Error())
-        .encode())
+      .withBody(JsonObject.mapFrom(new Error()).encode())
       .withHeader(CONTENT_TYPE, APPLICATION_JSON)
       .withStatus(404)));
 
@@ -172,8 +164,7 @@ public class QuickMarcApiTest extends ApiTestBase {
       .withParsedRecordDtoId(VALID_PARSED_RECORD_DTO_ID)
       .withInstanceId(EXISTED_INSTANCE_ID);
 
-    Error error = verifyPutRequest(String.format(RECORDS_EDITOR_RECORDS_PATH_ID, VALID_PARSED_RECORD_DTO_ID), quickMarcJson, 400)
-      .as(Error.class);
+    Error error = verifyPutRequest(String.format(RECORDS_EDITOR_RECORDS_PATH_ID, VALID_PARSED_RECORD_DTO_ID), quickMarcJson, 400).as(Error.class);
     assertThat(error.getType(), equalTo(ErrorUtils.ErrorType.INTERNAL.getTypeCode()));
 
     assertThat(wireMockServer.getAllServeEvents(), hasSize(0));
@@ -190,8 +181,7 @@ public class QuickMarcApiTest extends ApiTestBase {
       .withInstanceId(UUID.randomUUID()
         .toString());
 
-    Error error = verifyPutRequest(String.format(RECORDS_EDITOR_RECORDS_PATH_ID, VALID_PARSED_RECORD_ID), quickMarcJson,
-        HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()).as(Error.class);
+    Error error = verifyPutRequest(String.format(RECORDS_EDITOR_RECORDS_PATH_ID, VALID_PARSED_RECORD_ID), quickMarcJson, HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()).as(Error.class);
     assertThat(error.getType(), equalTo(ErrorUtils.ErrorType.INTERNAL.getTypeCode()));
 
     assertThat(wireMockServer.getAllServeEvents(), hasSize(0));
@@ -204,6 +194,7 @@ public class QuickMarcApiTest extends ApiTestBase {
     QuickMarcJson quickMarcJson = getJsonObject(QUICK_MARC_WRONG_ITEM_LENGTH).mapTo(QuickMarcJson.class)
       .withParsedRecordDtoId(VALID_PARSED_RECORD_DTO_ID)
       .withInstanceId(EXISTED_INSTANCE_ID);
+
     verifyPutRequest(String.format(RECORDS_EDITOR_RECORDS_PATH_ID, VALID_PARSED_RECORD_ID), quickMarcJson, 422);
   }
 
@@ -214,6 +205,7 @@ public class QuickMarcApiTest extends ApiTestBase {
     QuickMarcJson quickMarcJson = getJsonObject(QUICK_MARC_LEADER_MISMATCH).mapTo(QuickMarcJson.class)
       .withParsedRecordDtoId(VALID_PARSED_RECORD_DTO_ID)
       .withInstanceId(EXISTED_INSTANCE_ID);
+
     verifyPutRequest(String.format(RECORDS_EDITOR_RECORDS_PATH_ID, VALID_PARSED_RECORD_ID), quickMarcJson, 422);
   }
 }


### PR DESCRIPTION
[MODQM-20](https://issues.folio.org/browse/MODQM-20) - quickMARC: ParsedRecordDto -> QuickMarcJson error handling

## Purpose
In order to customize converter's exceptions one need to return error with source of issue description instead of generic internal server error.
## Approach
BE returns ConverterException with corresponding description if smith goes wrong with 006, 007, 008 fields.
## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
