### PR TITLE
MODQM-26 - Migrate mod-quick-marc to JDK 11

### DIFF
--- a/.rancher-pipeline.yml
+++ b/.rancher-pipeline.yml
@@ -1,0 +1,27 @@
+stages:
+- name: Build
+  steps:
+  - runScriptConfig:
+      image: maven:3-openjdk-8
+      shellScript: mvn package -DskipTests
+- name: Build Docker with DIND
+  steps:
+  - publishImageConfig:
+      dockerfilePath: ./Dockerfile
+      buildContext: .
+      tag: docker.dev.folio.org/mod-quick-marc:firebird-latest
+      pushRemote: true
+      registry: docker.dev.folio.org
+- name: Deploy
+  steps:
+  - applyAppConfig:
+      catalogTemplate: p-ngvqv:firebird-helmcharts-mod-quick-marc
+      version: 0.1.22
+      answers:
+        image.repository: docker.dev.folio.org/mod-quick-marc
+        image.tag: firebird-latest
+        postJob.enabled: true
+      targetNamespace: firebird
+      name: mod-quick-marc
+timeout: 60
+notification: {}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM folioci/alpine-jre-openjdk8:latest
+FROM folioci/alpine-jre-openjdk11:latest
 
 ENV VERTICLE_FILE mod-quick-marc-fat.jar
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@ buildMvn {
   publishAPI = true
   mvnDeploy = true
   runLintRamlCop = true
+  buildNode = 'jenkins-agent-java11'
 
   doDocker = {
     buildJavaDocker {

--- a/pom.xml
+++ b/pom.xml
@@ -14,9 +14,9 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>30.0.0</raml-module-builder.version>
+    <raml-module-builder.version>31.0.2</raml-module-builder.version>
     <jsonschema_paths>schemas</jsonschema_paths>
-    <vertx.version>3.9.0</vertx.version>
+    <vertx.version>3.9.2</vertx.version>
     <junit.jupiter.version>5.6.0</junit.jupiter.version>
     <rest-assured.version>4.3.0</rest-assured.version>
     <log4j-slf4j-impl.version>2.13.1</log4j-slf4j-impl.version>
@@ -268,9 +268,9 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
-        <version>1.11</version>
+        <version>1.12.6</version>
         <configuration>
           <verbose>true</verbose>
           <complianceLevel>1.8</complianceLevel>
@@ -299,12 +299,12 @@
           <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
-            <version>1.9.4</version>
+            <version>1.9.5</version>
           </dependency>
           <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjtools</artifactId>
-            <version>1.9.4</version>
+            <version>1.9.5</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -124,8 +124,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <release>11</release>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>


### PR DESCRIPTION
[MODQM-26](https://issues.folio.org/browse/MODQM-26) - Migrate mod-quick-marc to JDK 11

## Purpose
Migrate quickMARC to JDK 11.

## Approach
* Application is successfully builded on Java 11 platform
* Unit tests are completed without errors

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
