### PR TITLE
FOLIO-2898 Use new api-doc CI tool

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,9 +5,9 @@ buildMvn {
   buildNode = 'jenkins-agent-java11'
 
   doApiLint = true
+  doApiDoc = true
   apiTypes = 'RAML OAS'
   apiDirectories = 'ramls src/main/resources/swagger.api'
-  publishAPI = 'yes'
 
   doDocker = {
     buildDocker {


### PR DESCRIPTION
See [FOLIO-2898](https://issues.folio.org/browse/FOLIO-2898) and https://dev.folio.org/guides/jenkinsfile/#back-end-modules
Use `doApiDoc` in Jenkinsfile. Replaces `publishAPI`.