### PR TITLE
FOLSPRINGB-2 Reinstate 'USER folio' in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,8 @@ ARG RUN_ENV_FILE=run-env.sh
 COPY ${RUN_ENV_FILE} ${JAVA_APP_DIR}/
 RUN chmod 755 ${JAVA_APP_DIR}/${RUN_ENV_FILE}
 
+# Run as this user
+USER folio
+
 # Expose this port locally in the container.
 EXPOSE 8081


### PR DESCRIPTION
## Purpose
Reinstate "USER folio" in Dockerfile

## Approach
Reinstate user "folio" at the end of Dockerfile so that module runs on behalf of that user instead of "root"