### PR TITLE
MODQM-89 - Update POST /jobExecutions/{jobExecutionId}/records payload with required fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <records-editor.yaml.file>${project.basedir}/src/main/resources/swagger.api/records-editor.yaml</records-editor.yaml.file>
 
     <folio-spring-base.version>1.0.4</folio-spring-base.version>
-    <mod-srm-client.version>2.4.3</mod-srm-client.version>
+    <mod-srm-client.version>2.5.0-SNAPSHOT</mod-srm-client.version>
     <openapi-generator.version>4.3.1</openapi-generator.version>
     <mockito.version>3.7.7</mockito.version>
     <mapstruct.version>1.4.2.Final</mapstruct.version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <records-editor.yaml.file>${project.basedir}/src/main/resources/swagger.api/records-editor.yaml</records-editor.yaml.file>
 
     <folio-spring-base.version>1.0.4</folio-spring-base.version>
-    <mod-srm-client.version>2.5.0-SNAPSHOT</mod-srm-client.version>
+    <mod-srm-client.version>3.0.0</mod-srm-client.version>
     <openapi-generator.version>4.3.1</openapi-generator.version>
     <mockito.version>3.7.7</mockito.version>
     <mapstruct.version>1.4.2.Final</mapstruct.version>

--- a/src/main/java/org/folio/qm/util/ChangeManagerPayloadUtils.java
+++ b/src/main/java/org/folio/qm/util/ChangeManagerPayloadUtils.java
@@ -3,6 +3,8 @@ package org.folio.qm.util;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
+import java.util.UUID;
+
 import lombok.experimental.UtilityClass;
 
 import org.folio.rest.jaxrs.model.InitJobExecutionsRqDto;
@@ -31,6 +33,7 @@ public class ChangeManagerPayloadUtils {
 
   public static RawRecordsDto getRawRecordsBody(InitialRecord initialRecord, boolean isLast) {
     return new RawRecordsDto()
+      .withId(UUID.randomUUID().toString())
       .withInitialRecords(initialRecord == null ? emptyList(): singletonList(initialRecord))
       .withRecordsMetadata(
         new RecordsMetadata()

--- a/src/test/java/org/folio/qm/service/impl/MarcRecordsServiceImplTest.java
+++ b/src/test/java/org/folio/qm/service/impl/MarcRecordsServiceImplTest.java
@@ -106,7 +106,7 @@ class MarcRecordsServiceImplTest {
     doAnswer(InvocationOnMock::callRealMethod).when(converter).convert(
       argThat(quickMarc -> quickMarc.getFields().stream().noneMatch(field999Predicate.or(emptyContentPredicate))));
 
-    doAnswer(InvocationOnMock::callRealMethod).when(srmClient).postRawRecordsByJobExecutionId(any(),
+    doNothing().when(srmClient).postRawRecordsByJobExecutionId(any(),
       argThat(rawRecordsDto -> Objects.nonNull(rawRecordsDto.getId())));
 
     var actual = service.createNewInstance(quickMarcJson);

--- a/src/test/java/org/folio/qm/service/impl/MarcRecordsServiceImplTest.java
+++ b/src/test/java/org/folio/qm/service/impl/MarcRecordsServiceImplTest.java
@@ -14,6 +14,7 @@ import static org.folio.qm.utils.TestUtils.VALID_PARSED_RECORD_DTO_ID;
 import static org.folio.qm.utils.TestUtils.readQuickMarc;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Predicate;
 
@@ -102,10 +103,11 @@ class MarcRecordsServiceImplTest {
       return content instanceof String && Strings.isEmpty((String)content);
     };
 
-//    main check is come in the next block
     doAnswer(InvocationOnMock::callRealMethod).when(converter).convert(
-      argThat(argument -> argument.getFields().stream().noneMatch(field999Predicate.or(emptyContentPredicate))));
-    doNothing().when(srmClient).postRawRecordsByJobExecutionId(any(), any());
+      argThat(quickMarc -> quickMarc.getFields().stream().noneMatch(field999Predicate.or(emptyContentPredicate))));
+
+    doAnswer(InvocationOnMock::callRealMethod).when(srmClient).postRawRecordsByJobExecutionId(any(),
+      argThat(rawRecordsDto -> Objects.nonNull(rawRecordsDto.getId())));
 
     var actual = service.createNewInstance(quickMarcJson);
     assertThat(actual).isNotNull();


### PR DESCRIPTION
## Purpose
Update the RawRecordsDto payload based on the story - https://issues.folio.org/browse/MODQM-89

## Approach

* used the latest released version of 'mod-source-record-manager'
* updated test to check that uuid is generated for the POST requests