### PR TITLE
MODQM-84 Add standard admin healthcheck endpoint

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,8 +12,8 @@ buildMvn {
   doDocker = {
     buildDocker {
       publishMaster = 'yes'
-      healthChk = 'no'
-      healthChkCmd = 'curl -sS --fail -o /dev/null  http://localhost:8081/apidocs/ || exit 1'
+      healthChk = 'yes'
+      healthChkCmd = 'curl -sS --fail -o /dev/null http://localhost:8081/admin/health || exit 1'
     }
   }
 }

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -117,7 +117,7 @@
     "dockerPull": false,
     "dockerArgs": {
       "HostConfig": {
-        "Memory": 357913941,
+        "Memory": 536870912,
         "PortBindings": {
           "8081/tcp": [
             {
@@ -130,7 +130,7 @@
     "env": [
       {
         "name": "JAVA_OPTIONS",
-        "value": "-XX:MaxRAMPercentage=66.0"
+        "value": "-XX:MaxRAMPercentage=85.0"
       },
       {
         "name": "DB_HOST",

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,16 @@
       <version>${folio-spring-base.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
     </dependency>

--- a/run-env.sh
+++ b/run-env.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 DB_URL="jdbc:postgresql://${DB_HOST:-localhost}:${DB_PORT:-5432}/${DB_DATABASE:-db}"
-KAFKA_URL="${KAFKA_HOST}:${KAFKA_PORT}"
+KAFKA_URL="${KAFKA_HOST:-localhost}:${KAFKA_PORT:-9092}"
 OPTS="-Dspring.datasource.username=${DB_USERNAME:-user} -Dspring.datasource.password=${DB_PASSWORD:-pass} -Dspring.datasource.url=${DB_URL} -Dspring.kafka.bootstrap-servers=${KAFKA_URL}"
 export JAVA_OPTIONS="${JAVA_OPTIONS:-} ${OPTS}"

--- a/run-env.sh
+++ b/run-env.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-DB_URL="jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_DATABASE}"
+DB_URL="jdbc:postgresql://${DB_HOST:-localhost}:${DB_PORT:-5432}/${DB_DATABASE:-db}"
 KAFKA_URL="${KAFKA_HOST}:${KAFKA_PORT}"
-OPTS="-Dspring.datasource.username=${DB_USERNAME} -Dspring.datasource.password=${DB_PASSWORD} -Dspring.datasource.url=${DB_URL} -Dspring.kafka.bootstrap-servers=${KAFKA_URL}"
+OPTS="-Dspring.datasource.username=${DB_USERNAME:-user} -Dspring.datasource.password=${DB_PASSWORD:-pass} -Dspring.datasource.url=${DB_URL} -Dspring.kafka.bootstrap-servers=${KAFKA_URL}"
 export JAVA_OPTIONS="${JAVA_OPTIONS:-} ${OPTS}"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,7 +1,9 @@
 spring:
   application:
     name: mod-quick-marc
-#  datasource:
+  datasource:
+    # to boot up application despite of any DB connection issues
+    continue-on-error: true
 #    password: folio_admin
 #    url: jdbc:postgresql://localhost:5432/okapi_modules
 #    username: folio_admin
@@ -16,6 +18,7 @@ spring:
       ddl-auto: none
     properties:
       hibernate:
+        dialect: org.hibernate.dialect.PostgreSQL10Dialect
         format_sql: true
     show-sql: true
   liquibase:
@@ -37,6 +40,19 @@ management:
     web:
       exposure:
         include: info,health,env,httptrace
+      base-path: /admin
+#  endpoint:
+#    health:
+#      show-details: always
+#      show-components: always
+###################################################
+# Disable all checks except for readiness
+###################################################
+  health:
+    defaults:
+      enabled: false
+    readinessstate:
+      enabled: true
 server:
   port: 8081
 job:


### PR DESCRIPTION
## Purpose
Add admin health-check endpoint with Url: /admin/health

## Approach
Utilize Sprint boot actuator health check. Replace standard path to /admin/health via app property. Enable health check in Jenkins settings