### PR TITLE
Add lombok config

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,878 @@
+##
+## Key : checkerframework
+## Type: checkerframework-version
+##
+## If set with the version of checkerframework.org (in major.minor, or just 'true' for the latest supported version), create relevant checkerframework.org annotations for code lombok generates (default: false).
+##
+## Examples:
+#
+# clear checkerframework
+# checkerframework = major.minor (example: 3.2 - and no higher than 4.0) or true or false
+#
+
+##
+## Key : config.stopBubbling
+## Type: boolean
+##
+## Tell the configuration system it should stop looking for other configuration files (default: false).
+##
+## Examples:
+#
+# clear config.stopBubbling
+config.stopBubbling = true
+#
+
+##
+## Key : lombok.accessors.chain
+## Type: boolean
+##
+## Generate setters that return 'this' instead of 'void' (default: false).
+##
+## Examples:
+#
+# clear lombok.accessors.chain
+# lombok.accessors.chain = [false | true]
+#
+
+##
+## Key : lombok.accessors.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @Accessors is used.
+##
+## Examples:
+#
+# clear lombok.accessors.flagUsage
+# lombok.accessors.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.accessors.fluent
+## Type: boolean
+##
+## Generate getters and setters using only the field name (no get/set prefix) (default: false).
+##
+## Examples:
+#
+# clear lombok.accessors.fluent
+# lombok.accessors.fluent = [false | true]
+#
+
+##
+## Key : lombok.accessors.prefix
+## Type: list of string
+##
+## Strip this field prefix, like 'f' or 'm_', from the names of generated getters and setters.
+##
+## Examples:
+#
+# clear lombok.accessors.prefix
+# lombok.accessors.prefix += <text>
+# lombok.accessors.prefix -= <text>
+#
+
+##
+## Key : lombok.addGeneratedAnnotation
+## Type: boolean
+##
+## Generate @javax.annotation.Generated on all generated code (default: false). Deprecated, use 'lombok.addJavaxGeneratedAnnotation' instead.
+##
+## Examples:
+#
+# clear lombok.addGeneratedAnnotation
+# lombok.addGeneratedAnnotation = [false | true]
+#
+
+##
+## Key : lombok.addJavaxGeneratedAnnotation
+## Type: boolean
+##
+## Generate @javax.annotation.Generated on all generated code (default: follow lombok.addGeneratedAnnotation).
+##
+## Examples:
+#
+# clear lombok.addJavaxGeneratedAnnotation
+# lombok.addJavaxGeneratedAnnotation = [false | true]
+#
+
+##
+## Key : lombok.addLombokGeneratedAnnotation
+## Type: boolean
+##
+## Generate @lombok.Generated on all generated code (default: false).
+##
+## Examples:
+#
+# clear lombok.addLombokGeneratedAnnotation
+lombok.addLombokGeneratedAnnotation = true
+#
+
+##
+## Key : lombok.addNullAnnotations
+## Type: nullity-annotation-library
+##
+## Generate some style of null annotation for generated code where this is relevant. (default: none).
+##
+## Examples:
+#
+# clear lombok.addNullAnnotations
+# lombok.addNullAnnotations = none | javax | eclipse | jetbrains | netbeans | androidx | android.support | checkerframework | findbugs | spring | jml | CUSTOM:com.foo.my.nonnull.annotation:com.foo.my.nullable.annotation
+#
+
+##
+## Key : lombok.addSuppressWarnings
+## Type: boolean
+##
+## Generate @java.lang.SuppressWarnings("all") on all generated code (default: true).
+##
+## Examples:
+#
+# clear lombok.addSuppressWarnings
+# lombok.addSuppressWarnings = [false | true]
+#
+
+##
+## Key : lombok.allArgsConstructor.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @AllArgsConstructor is used.
+##
+## Examples:
+#
+# clear lombok.allArgsConstructor.flagUsage
+# lombok.allArgsConstructor.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.anyConstructor.addConstructorProperties
+## Type: boolean
+##
+## Generate @ConstructorProperties for generated constructors (default: false).
+##
+## Examples:
+#
+# clear lombok.anyConstructor.addConstructorProperties
+# lombok.anyConstructor.addConstructorProperties = [false | true]
+#
+
+##
+## Key : lombok.anyConstructor.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if any of the XxxArgsConstructor annotations are used.
+##
+## Examples:
+#
+# clear lombok.anyConstructor.flagUsage
+# lombok.anyConstructor.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.anyConstructor.suppressConstructorProperties
+## Type: boolean
+##
+## Suppress the generation of @ConstructorProperties for generated constructors (default: false).
+##
+## Examples:
+#
+# clear lombok.anyConstructor.suppressConstructorProperties
+# lombok.anyConstructor.suppressConstructorProperties = [false | true]
+#
+
+##
+## Key : lombok.builder.className
+## Type: string
+##
+## Default name of the generated builder class. A * is replaced with the name of the relevant type (default = *Builder).
+##
+## Examples:
+#
+# clear lombok.builder.className
+# lombok.builder.className = <text>
+#
+
+##
+## Key : lombok.builder.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @Builder is used.
+##
+## Examples:
+#
+# clear lombok.builder.flagUsage
+# lombok.builder.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.cleanup.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @Cleanup is used.
+##
+## Examples:
+#
+# clear lombok.cleanup.flagUsage
+# lombok.cleanup.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.copyableAnnotations
+## Type: list of type-name
+##
+## Copy these annotations to getters, setters, with methods, builder-setters, etc.
+##
+## Examples:
+#
+# clear lombok.copyableAnnotations
+# lombok.copyableAnnotations += <fully.qualified.Type>
+# lombok.copyableAnnotations -= <fully.qualified.Type>
+#
+
+##
+## Key : lombok.data.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @Data is used.
+##
+## Examples:
+#
+# clear lombok.data.flagUsage
+# lombok.data.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.delegate.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @Delegate is used.
+##
+## Examples:
+#
+# clear lombok.delegate.flagUsage
+# lombok.delegate.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.equalsAndHashCode.callSuper
+## Type: enum (lombok.core.configuration.CallSuperType)
+##
+## When generating equals and hashCode for classes that extend something (other than Object), either automatically take into account superclass implementation (call), or don't (skip), or warn and don't (warn). (default = warn).
+##
+## Examples:
+#
+# clear lombok.equalsAndHashCode.callSuper
+# lombok.equalsAndHashCode.callSuper = [CALL | SKIP | WARN]
+#
+
+##
+## Key : lombok.equalsAndHashCode.doNotUseGetters
+## Type: boolean
+##
+## Don't call the getters but use the fields directly in the generated equals and hashCode method (default = false).
+##
+## Examples:
+#
+# clear lombok.equalsAndHashCode.doNotUseGetters
+# lombok.equalsAndHashCode.doNotUseGetters = [false | true]
+#
+
+##
+## Key : lombok.equalsAndHashCode.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @EqualsAndHashCode is used.
+##
+## Examples:
+#
+# clear lombok.equalsAndHashCode.flagUsage
+# lombok.equalsAndHashCode.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.experimental.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if an experimental feature is used.
+##
+## Examples:
+#
+# clear lombok.experimental.flagUsage
+# lombok.experimental.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.extensionMethod.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @ExtensionMethod is used.
+##
+## Examples:
+#
+# clear lombok.extensionMethod.flagUsage
+# lombok.extensionMethod.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.extern.findbugs.addSuppressFBWarnings
+## Type: boolean
+##
+## Generate @edu.umd.cs.findbugs.annotations.SuppressFBWarnings on all generated code (default: false).
+##
+## Examples:
+#
+# clear lombok.extern.findbugs.addSuppressFBWarnings
+# lombok.extern.findbugs.addSuppressFBWarnings = [false | true]
+#
+
+##
+## Key : lombok.fieldDefaults.defaultFinal
+## Type: boolean
+##
+## If true, fields, in any file (lombok annotated or not) are marked as final. Use @NonFinal to override this.
+##
+## Examples:
+#
+# clear lombok.fieldDefaults.defaultFinal
+# lombok.fieldDefaults.defaultFinal = [false | true]
+#
+
+##
+## Key : lombok.fieldDefaults.defaultPrivate
+## Type: boolean
+##
+## If true, fields without any access modifier, in any file (lombok annotated or not) are marked as private. Use @PackagePrivate or an explicit modifier to override this.
+##
+## Examples:
+#
+# clear lombok.fieldDefaults.defaultPrivate
+# lombok.fieldDefaults.defaultPrivate = [false | true]
+#
+
+##
+## Key : lombok.fieldDefaults.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @FieldDefaults is used.
+##
+## Examples:
+#
+# clear lombok.fieldDefaults.flagUsage
+# lombok.fieldDefaults.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.fieldNameConstants.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @FieldNameConstants is used.
+##
+## Examples:
+#
+# clear lombok.fieldNameConstants.flagUsage
+# lombok.fieldNameConstants.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.fieldNameConstants.innerTypeName
+## Type: identifier-name
+##
+## The default name of the inner type generated by @FieldNameConstants. (default: 'Fields').
+##
+## Examples:
+#
+# clear lombok.fieldNameConstants.innerTypeName
+# lombok.fieldNameConstants.innerTypeName = <javaIdentifier>
+#
+
+##
+## Key : lombok.fieldNameConstants.uppercase
+## Type: boolean
+##
+## The default name of the constants inside the inner type generated by @FieldNameConstants follow the variable name precisely. If this config key is true, lombok will uppercase them as best it can. (default: false).
+##
+## Examples:
+#
+# clear lombok.fieldNameConstants.uppercase
+# lombok.fieldNameConstants.uppercase = [false | true]
+#
+
+##
+## Key : lombok.getter.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @Getter is used.
+##
+## Examples:
+#
+# clear lombok.getter.flagUsage
+# lombok.getter.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.getter.lazy.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @Getter(lazy=true) is used.
+##
+## Examples:
+#
+# clear lombok.getter.lazy.flagUsage
+# lombok.getter.lazy.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.getter.noIsPrefix
+## Type: boolean
+##
+## If true, generate and use getFieldName() for boolean getters instead of isFieldName().
+##
+## Examples:
+#
+# clear lombok.getter.noIsPrefix
+# lombok.getter.noIsPrefix = [false | true]
+#
+
+##
+## Key : lombok.helper.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @Helper is used.
+##
+## Examples:
+#
+# clear lombok.helper.flagUsage
+# lombok.helper.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.jacksonized.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @Jacksonized is used.
+##
+## Examples:
+#
+# clear lombok.jacksonized.flagUsage
+# lombok.jacksonized.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.log.apacheCommons.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @CommonsLog is used.
+##
+## Examples:
+#
+# clear lombok.log.apacheCommons.flagUsage
+# lombok.log.apacheCommons.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.log.custom.declaration
+## Type: custom-log-declaration
+##
+## Define the generated custom logger field.
+##
+## Examples:
+#
+# clear lombok.log.custom.declaration
+# lombok.log.custom.declaration = my.cool.Logger my.cool.LoggerFactory.createLogger()(TOPIC,TYPE)
+#
+
+##
+## Key : lombok.log.custom.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @CustomLog is used.
+##
+## Examples:
+#
+# clear lombok.log.custom.flagUsage
+# lombok.log.custom.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.log.fieldIsStatic
+## Type: boolean
+##
+## Make the generated logger fields static (default: true).
+##
+## Examples:
+#
+# clear lombok.log.fieldIsStatic
+# lombok.log.fieldIsStatic = [false | true]
+#
+
+##
+## Key : lombok.log.fieldName
+## Type: identifier-name
+##
+## Use this name for the generated logger fields (default: 'log').
+##
+## Examples:
+#
+# clear lombok.log.fieldName
+# lombok.log.fieldName = <javaIdentifier>
+#
+
+##
+## Key : lombok.log.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if any of the log annotations is used.
+##
+## Examples:
+#
+# clear lombok.log.flagUsage
+# lombok.log.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.log.flogger.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @Flogger is used.
+##
+## Examples:
+#
+# clear lombok.log.flogger.flagUsage
+# lombok.log.flogger.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.log.javaUtilLogging.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @Log is used.
+##
+## Examples:
+#
+# clear lombok.log.javaUtilLogging.flagUsage
+# lombok.log.javaUtilLogging.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.log.jbosslog.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @JBossLog is used.
+##
+## Examples:
+#
+# clear lombok.log.jbosslog.flagUsage
+# lombok.log.jbosslog.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.log.log4j.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @Log4j is used.
+##
+## Examples:
+#
+# clear lombok.log.log4j.flagUsage
+# lombok.log.log4j.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.log.log4j2.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @Log4j2 is used.
+##
+## Examples:
+#
+# clear lombok.log.log4j2.flagUsage
+# lombok.log.log4j2.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.log.slf4j.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @Slf4j is used.
+##
+## Examples:
+#
+# clear lombok.log.slf4j.flagUsage
+# lombok.log.slf4j.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.log.xslf4j.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @XSlf4j is used.
+##
+## Examples:
+#
+# clear lombok.log.xslf4j.flagUsage
+# lombok.log.xslf4j.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.noArgsConstructor.extraPrivate
+## Type: boolean
+##
+## Generate a private no-args constructor for @Data and @Value (default: false).
+##
+## Examples:
+#
+# clear lombok.noArgsConstructor.extraPrivate
+# lombok.noArgsConstructor.extraPrivate = [false | true]
+#
+
+##
+## Key : lombok.noArgsConstructor.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @NoArgsConstructor is used.
+##
+## Examples:
+#
+# clear lombok.noArgsConstructor.flagUsage
+# lombok.noArgsConstructor.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.nonNull.exceptionType
+## Type: enum (lombok.core.configuration.NullCheckExceptionType)
+##
+## The type of the exception to throw if a passed-in argument is null (Default: NullPointerException).
+##
+## Examples:
+#
+# clear lombok.nonNull.exceptionType
+# lombok.nonNull.exceptionType = [NullPointerException | IllegalArgumentException | Assertion | JDK | Guava]
+#
+
+##
+## Key : lombok.nonNull.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @NonNull is used.
+##
+## Examples:
+#
+# clear lombok.nonNull.flagUsage
+# lombok.nonNull.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.onX.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if onX is used.
+##
+## Examples:
+#
+# clear lombok.onX.flagUsage
+# lombok.onX.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.requiredArgsConstructor.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @RequiredArgsConstructor is used.
+##
+## Examples:
+#
+# clear lombok.requiredArgsConstructor.flagUsage
+# lombok.requiredArgsConstructor.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.setter.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @Setter is used.
+##
+## Examples:
+#
+# clear lombok.setter.flagUsage
+# lombok.setter.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.singular.auto
+## Type: boolean
+##
+## If true (default): Automatically singularize the assumed-to-be-plural name of your variable/parameter when using @Singular.
+##
+## Examples:
+#
+# clear lombok.singular.auto
+# lombok.singular.auto = [false | true]
+#
+
+##
+## Key : lombok.singular.useGuava
+## Type: boolean
+##
+## Generate backing immutable implementations for @Singular on java.util.* types by using guava's ImmutableList, etc. Normally java.util's mutable types are used and wrapped to make them immutable.
+##
+## Examples:
+#
+# clear lombok.singular.useGuava
+# lombok.singular.useGuava = [false | true]
+#
+
+##
+## Key : lombok.sneakyThrows.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @SneakyThrows is used.
+##
+## Examples:
+#
+# clear lombok.sneakyThrows.flagUsage
+# lombok.sneakyThrows.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.superBuilder.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @SuperBuilder is used.
+##
+## Examples:
+#
+# clear lombok.superBuilder.flagUsage
+# lombok.superBuilder.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.synchronized.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @Synchronized is used.
+##
+## Examples:
+#
+# clear lombok.synchronized.flagUsage
+# lombok.synchronized.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.toString.callSuper
+## Type: enum (lombok.core.configuration.CallSuperType)
+##
+## When generating toString for classes that extend something (other than Object), either automatically take into account superclass implementation (call), or don't (skip), or warn and don't (warn). (default = skip).
+##
+## Examples:
+#
+# clear lombok.toString.callSuper
+# lombok.toString.callSuper = [CALL | SKIP | WARN]
+#
+
+##
+## Key : lombok.toString.doNotUseGetters
+## Type: boolean
+##
+## Don't call the getters but use the fields directly in the generated toString method (default = false).
+##
+## Examples:
+#
+# clear lombok.toString.doNotUseGetters
+# lombok.toString.doNotUseGetters = [false | true]
+#
+
+##
+## Key : lombok.toString.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @ToString is used.
+##
+## Examples:
+#
+# clear lombok.toString.flagUsage
+# lombok.toString.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.toString.includeFieldNames
+## Type: boolean
+##
+## Include the field names in the generated toString method (default = true).
+##
+## Examples:
+#
+# clear lombok.toString.includeFieldNames
+# lombok.toString.includeFieldNames = [false | true]
+#
+
+##
+## Key : lombok.utilityClass.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @UtilityClass is used.
+##
+## Examples:
+#
+# clear lombok.utilityClass.flagUsage
+# lombok.utilityClass.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.val.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if 'val' is used.
+##
+## Examples:
+#
+# clear lombok.val.flagUsage
+# lombok.val.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.value.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @Value is used.
+##
+## Examples:
+#
+# clear lombok.value.flagUsage
+# lombok.value.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.var.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if 'var' is used.
+##
+## Examples:
+#
+# clear lombok.var.flagUsage
+# lombok.var.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.with.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @With is used.
+##
+## Examples:
+#
+# clear lombok.with.flagUsage
+# lombok.with.flagUsage = [WARNING | ERROR | ALLOW]
+#
+
+##
+## Key : lombok.withBy.flagUsage
+## Type: enum (lombok.core.configuration.FlagUsageType)
+##
+## Emit a warning or error if @WithBy is used.
+##
+## Examples:
+#
+# clear lombok.withBy.flagUsage
+# lombok.withBy.flagUsage = [WARNING | ERROR | ALLOW]
+#
+


### PR DESCRIPTION
## Purpose
Add lombok configuration file to tune coverage evaluation by skipping generated code

## Approach
* add lombok.config to project's root folder with `lombok.addLombokGeneratedAnnotation` turned on