### PR TITLE
Revert "Bump openapi-generator-maven-plugin from 4.3.1 to 5.1.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <folio-spring-base.version>1.0.5</folio-spring-base.version>
     <mod-srm-client.version>3.0.0</mod-srm-client.version>
-    <openapi-generator.version>5.1.0</openapi-generator.version>
+    <openapi-generator.version>4.3.1</openapi-generator.version>
     <mockito.version>3.7.7</mockito.version>
     <mapstruct.version>1.4.2.Final</mapstruct.version>
     <commons-lang.version>2.6</commons-lang.version>


### PR DESCRIPTION
Reverts folio-org/mod-quick-marc#88