### PR TITLE
MODQM-126 Sort fields by tag code

### DIFF
--- a/src/main/java/org/folio/qm/converter/ParsedRecordDtoToQuickMarcConverter.java
+++ b/src/main/java/org/folio/qm/converter/ParsedRecordDtoToQuickMarcConverter.java
@@ -25,6 +25,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,6 +55,9 @@ import org.folio.rest.jaxrs.model.ParsedRecordDto;
 @Component
 public class ParsedRecordDtoToQuickMarcConverter implements Converter<ParsedRecordDto, QuickMarc> {
 
+  private static final Comparator<QuickMarcFields> QUICK_MARC_FIELDS_COMPARATOR =
+    Comparator.comparingInt(o -> Integer.parseInt(o.getTag()));
+
   private MaterialTypeConfiguration materialTypeConfiguration;
 
   @Override
@@ -75,6 +79,8 @@ public class ParsedRecordDtoToQuickMarcConverter implements Converter<ParsedReco
         .stream()
         .map(this::dataFieldToQuickMarcField)
         .collect(Collectors.toList()));
+
+      fields.sort(QUICK_MARC_FIELDS_COMPARATOR);
 
       return new QuickMarc().parsedRecordId(parsedRecord.getId())
         .leader(leader)

--- a/src/test/java/org/folio/qm/conveter/ParsedRecordDtoToQuickMarcConverterTest.java
+++ b/src/test/java/org/folio/qm/conveter/ParsedRecordDtoToQuickMarcConverterTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
 import static org.folio.qm.utils.AssertionUtils.mockIsEqualToObject;
 import static org.folio.qm.utils.JsonTestUtils.getMockAsObject;
 import static org.folio.qm.utils.testentities.TestEntitiesUtils.PARSED_RECORD_DTO_PATH;
+import static org.folio.qm.utils.testentities.TestEntitiesUtils.PARSED_RECORD_DTO_UNSORTED_PATH;
 import static org.folio.qm.utils.testentities.TestEntitiesUtils.PARSED_RECORD_EDGE_CASES_PATH;
 import static org.folio.qm.utils.testentities.TestEntitiesUtils.QM_RECORD_EDGE_CASES_PATH;
 import static org.folio.qm.utils.testentities.TestEntitiesUtils.QM_RECORD_PATH;
@@ -57,8 +58,11 @@ class ParsedRecordDtoToQuickMarcConverterTest {
   }
 
   @ParameterizedTest
-  @CsvSource(value = {PARSED_RECORD_DTO_PATH + "," + QM_RECORD_PATH,
-    PARSED_RECORD_EDGE_CASES_PATH + "," + QM_RECORD_EDGE_CASES_PATH})
+  @CsvSource(value = {
+    PARSED_RECORD_DTO_PATH + "," + QM_RECORD_PATH,
+    PARSED_RECORD_EDGE_CASES_PATH + "," + QM_RECORD_EDGE_CASES_PATH,
+    PARSED_RECORD_DTO_UNSORTED_PATH + "," + QM_RECORD_PATH
+  })
   void testParsedRecordToQuickMarcJsonConversion(String parsedRecordDtoPath, String quickMarcJsonPath) {
     logger.info("Testing ParsedRecord -> QuickMarcJson conversion (expected flow + edge cases)");
     ParsedRecordDtoToQuickMarcConverter converter = new ParsedRecordDtoToQuickMarcConverter();

--- a/src/test/java/org/folio/qm/utils/testentities/TestEntitiesUtils.java
+++ b/src/test/java/org/folio/qm/utils/testentities/TestEntitiesUtils.java
@@ -21,6 +21,7 @@ public class TestEntitiesUtils {
   public static final String PARSED_RECORD_EDGE_CASES_PATH = QM_JSON_DIR + "/parsedRecordDtoMissingWhitespaces.json";
   public static final String USER_JOHN_PATH = "mockdata/users/userJohn.json";
   public static final String PARSED_RECORD_DTO_PATH = QM_JSON_DIR + "/parsedRecordDto.json";
+  public static final String PARSED_RECORD_DTO_UNSORTED_PATH = QM_JSON_DIR + "/parsedRecordDtoUnsorted.json";
   public static final String PARSED_RECORDS_DIR = "mockdata/quick-marc-json";
   public static final String QM_EMPTY_FIELDS = PARSED_RECORDS_DIR + "/quickMarcJson_emptyContent.json";
   public static final String QM_WRONG_ITEM_LENGTH = PARSED_RECORDS_DIR + "/quickMarcJsonWrongItemLength.json";

--- a/src/test/resources/mockdata/change-manager/parsedRecordDtoUnsorted.json
+++ b/src/test/resources/mockdata/change-manager/parsedRecordDtoUnsorted.json
@@ -1,0 +1,500 @@
+{
+  "id": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
+  "externalIdsHolder": {
+    "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817"
+  },
+  "recordType": "MARC_BIB",
+  "parsedRecord": {
+    "id": "c9db5d7a-e1d4-11e8-9f32-f2801f1b9fd1",
+    "content": {
+      "fields": [
+        {
+          "001": "393893"
+        },
+        {
+          "005": "20141107001016.0"
+        },
+        {
+          "006": "c bcdefghijklmn o "
+        },
+        {
+          "007": "sa bcdefghijkl"
+        },
+        {
+          "008": "abcdefghijklmnopqr bcdefghijklmn o stuvw"
+        },
+        {
+          "948": {
+            "ind1": "1",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "20100622"
+              },
+              {
+                "b": "s"
+              },
+              {
+                "d": "lap11"
+              },
+              {
+                "e": "lts"
+              },
+              {
+                "x": "ToAddCatStat"
+              }
+            ]
+          }
+        },
+        {
+          "948": {
+            "ind1": "0",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "20110818"
+              },
+              {
+                "b": "r"
+              },
+              {
+                "d": "np55"
+              },
+              {
+                "e": "lts"
+              }
+            ]
+          }
+        },
+        {
+          "948": {
+            "ind1": "2",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "20130128"
+              },
+              {
+                "b": "m"
+              },
+              {
+                "d": "bmt1"
+              },
+              {
+                "e": "lts"
+              }
+            ]
+          }
+        },
+        {
+          "040": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "c": "UPB"
+              },
+              {
+                "d": "UPB"
+              },
+              {
+                "d": "NIC"
+              },
+              {
+                "d": "NIC"
+              }
+            ]
+          }
+        },
+        {
+          "041": {
+            "ind1": "0",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "latitager"
+              },
+              {
+                "g": "ger"
+              }
+            ]
+          }
+        },
+        {
+          "010": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "  2001000234"
+              }
+            ]
+          }
+        },
+        {
+          "035": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "(OCoLC)63611770"
+              }
+            ]
+          }
+        },
+        {
+          "035": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "393893"
+              }
+            ]
+          }
+        },
+        {
+          "045": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "v6v9"
+              }
+            ]
+          }
+        },
+        {
+          "245": {
+            "ind1": "1",
+            "ind2": "0",
+            "subfields": [
+              {
+                "a": "Neue Ausgabe samtlicher Werke,"
+              },
+              {
+                "b": "in Verbindung mit den Mozartstadten, Augsburg, Salzburg und Wien."
+              },
+              {
+                "c": "Hrsg. von der Internationalen Stiftung Mozarteum, Salzburg."
+              }
+            ]
+          }
+        },
+        {
+          "246": {
+            "ind1": "3",
+            "ind2": "3",
+            "subfields": [
+              {
+                "a": "Neue Mozart-Ausgabe"
+              }
+            ]
+          }
+        },
+        {
+          "260": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "Kassel,"
+              },
+              {
+                "b": "Barenreiter,"
+              },
+              {
+                "c": "c1955-"
+              }
+            ]
+          }
+        },
+        {
+          "300": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "v."
+              },
+              {
+                "b": "facsims."
+              },
+              {
+                "c": "33 cm."
+              }
+            ]
+          }
+        },
+        {
+          "505": {
+            "ind1": "0",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "Ser. I. Geistliche Gesangswerke -- Ser. II. Opern -- Ser. III. Lieder, mehrstimmige Gesange, Kanons -- Ser. IV. Orchesterwerke -- Ser. V. Konzerte -- Ser. VI. Kirchensonaten -- Ser. VII. Ensemblemusik fur grossere Solobesetzungen -- Ser. VIII. Kammermusik -- Ser. IX. Klaviermusik -- Ser. X. Supplement."
+              }
+            ]
+          }
+        },
+        {
+          "590": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "Purchase price: $325.00, 1980 August."
+              }
+            ]
+          }
+        },
+        {
+          "650": {
+            "ind1": " ",
+            "ind2": "0",
+            "subfields": [
+              {
+                "a": "Vocal music"
+              }
+            ]
+          }
+        },
+        {
+          "650": {
+            "ind1": " ",
+            "ind2": "0",
+            "subfields": [
+              {
+                "a": "Instrumental music"
+              }
+            ]
+          }
+        },
+        {
+          "650": {
+            "ind1": " ",
+            "ind2": "7",
+            "subfields": [
+              {
+                "a": "Instrumental music"
+              },
+              {
+                "2": "fast"
+              },
+              {
+                "0": "(OCoLC)fst00974414"
+              }
+            ]
+          }
+        },
+        {
+          "650": {
+            "ind1": " ",
+            "ind2": "7",
+            "subfields": [
+              {
+                "a": "Vocal music"
+              },
+              {
+                "2": "fast"
+              },
+              {
+                "0": "(OCoLC)fst01168379"
+              }
+            ]
+          }
+        },
+        {
+          "047": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "cn"
+              },
+              {
+                "a": "ct"
+              },
+              {
+                "a": "co"
+              },
+              {
+                "a": "df"
+              },
+              {
+                "a": "dv"
+              },
+              {
+                "a": "ft"
+              },
+              {
+                "a": "fg"
+              },
+              {
+                "a": "ms"
+              },
+              {
+                "a": "mi"
+              },
+              {
+                "a": "nc"
+              },
+              {
+                "a": "op"
+              },
+              {
+                "a": "ov"
+              },
+              {
+                "a": "rq"
+              },
+              {
+                "a": "sn"
+              },
+              {
+                "a": "su"
+              },
+              {
+                "a": "sy"
+              },
+              {
+                "a": "vr"
+              },
+              {
+                "a": "zz"
+              }
+            ]
+          }
+        },
+        {
+          "050": {
+            "ind1": "0",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "M3"
+              },
+              {
+                "b": ".M896"
+              }
+            ]
+          }
+        },
+        {
+          "066": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "c": "$1"
+              },
+              {
+                "c": "(3"
+              }
+            ]
+          }
+        },
+        {
+          "100": {
+            "ind1": "1",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "Mozart, Wolfgang Amadeus,"
+              },
+              {
+                "d": "1756-1791."
+              }
+            ]
+          }
+        },
+        {
+          "240": {
+            "ind1": "1",
+            "ind2": "0",
+            "subfields": [
+              {
+                "a": "Works"
+              }
+            ]
+          }
+        },
+        {
+          "880": {
+            "ind1": "0",
+            "ind2": "0",
+            "subfields": [
+              {
+                "6": "245-01/$1"
+              },
+              {
+                "a": "abcde /"
+              },
+              {
+                "c": "fghij"
+              }
+            ]
+          }
+        },
+        {
+          "902": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "pfnd"
+              },
+              {
+                "b": "Austin Music"
+              }
+            ]
+          }
+        },
+        {
+          "905": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "19980728120000.0"
+              }
+            ]
+          }
+        },
+
+        {
+          "948": {
+            "ind1": "2",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "20141106"
+              },
+              {
+                "b": "m"
+              },
+              {
+                "d": "batch"
+              },
+              {
+                "e": "lts"
+              },
+              {
+                "x": "addfast"
+              }
+            ]
+          }
+        }
+      ],
+      "leader": "01706ccm a2200361   4500"
+    }
+  },
+  "additionalInfo": {
+    "suppressDiscovery": false
+  },
+  "recordState": "ACTUAL",
+  "metadata": {
+    "updatedDate": "2020-07-16T15:13:36.879+03:00",
+    "updatedByUserId": "38d3a441-c100-5e8d-bd12-71bde492b723"
+  }
+}


### PR DESCRIPTION
## Purpose
Sort fields by tag code before responding on GET /record.

## Approach
Add integer comparator to sort fields in srm-to-qm converter