### PR TITLE
MODQM-145 Fix Kafka listeners not subscribed

### DIFF
--- a/src/main/java/org/folio/qm/config/KafkaConfig.java
+++ b/src/main/java/org/folio/qm/config/KafkaConfig.java
@@ -1,5 +1,7 @@
 package org.folio.qm.config;
 
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.RoundRobinAssignor;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.annotation.Value;
@@ -27,6 +29,7 @@ public class KafkaConfig {
   public ConsumerFactory<String, DataImportEventPayload> dataImportConsumerFactory(KafkaProperties kafkaProperties,
                                                                          Deserializer<DataImportEventPayload> deserializer) {
     var consumerProperties = kafkaProperties.buildConsumerProperties();
+    consumerProperties.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, RoundRobinAssignor.class.getName());
     return new DefaultKafkaConsumerFactory<>(consumerProperties, new StringDeserializer(), deserializer);
   }
 
@@ -34,6 +37,7 @@ public class KafkaConfig {
   public ConcurrentKafkaListenerContainerFactory<String, DataImportEventPayload> dataImportKafkaListenerContainerFactory(
     ConsumerFactory<String, DataImportEventPayload> consumerFactory) {
     var factory = new ConcurrentKafkaListenerContainerFactory<String, DataImportEventPayload>();
+    factory.setConcurrency(3);
     factory.setConsumerFactory(consumerFactory);
     return factory;
   }
@@ -42,6 +46,7 @@ public class KafkaConfig {
   public ConsumerFactory<String, QmCompletedEventPayload> quickMarcConsumerFactory(KafkaProperties kafkaProperties,
                                                                                    Deserializer<QmCompletedEventPayload> deserializer) {
     var consumerProperties = kafkaProperties.buildConsumerProperties();
+    consumerProperties.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, RoundRobinAssignor.class.getName());
     return new DefaultKafkaConsumerFactory<>(consumerProperties, new StringDeserializer(), deserializer);
   }
 
@@ -49,6 +54,7 @@ public class KafkaConfig {
   public ConcurrentKafkaListenerContainerFactory<String, QmCompletedEventPayload> quickMarcKafkaListenerContainerFactory(
     ConsumerFactory<String, QmCompletedEventPayload> consumerFactory) {
     var factory = new ConcurrentKafkaListenerContainerFactory<String, QmCompletedEventPayload>();
+    factory.setConcurrency(3);
     factory.setConsumerFactory(consumerFactory);
     return factory;
   }

--- a/src/main/java/org/folio/qm/controller/QmTenantController.java
+++ b/src/main/java/org/folio/qm/controller/QmTenantController.java
@@ -1,0 +1,35 @@
+package org.folio.qm.controller;
+
+import javax.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import org.folio.qm.messaging.topic.KafkaTopicsInitializer;
+import org.folio.spring.controller.TenantController;
+import org.folio.spring.service.TenantService;
+import org.folio.tenant.domain.dto.TenantAttributes;
+
+@RestController("folioTenantController")
+@RequestMapping(value = "/_/")
+public class QmTenantController extends TenantController {
+
+  private final KafkaTopicsInitializer kafkaTopicsInitializer;
+
+  public QmTenantController(TenantService tenantService,
+                            KafkaTopicsInitializer kafkaTopicsInitializer) {
+    super(tenantService);
+    this.kafkaTopicsInitializer = kafkaTopicsInitializer;
+  }
+
+  @Override
+  public ResponseEntity<String> postTenant(@Valid TenantAttributes tenantAttributes) {
+    var responseEntity = super.postTenant(tenantAttributes);
+    if (responseEntity.getStatusCode() == HttpStatus.OK) {
+      kafkaTopicsInitializer.createTopics();
+    }
+    return responseEntity;
+  }
+}

--- a/src/main/java/org/folio/qm/messaging/topic/KafkaTopicsInitializer.java
+++ b/src/main/java/org/folio/qm/messaging/topic/KafkaTopicsInitializer.java
@@ -1,0 +1,75 @@
+package org.folio.qm.messaging.topic;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.KafkaAdmin;
+import org.springframework.stereotype.Component;
+
+import org.folio.qm.messaging.domain.QmEventTypes;
+import org.folio.rest.jaxrs.model.DataImportEventTypes;
+import org.folio.spring.FolioExecutionContext;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class KafkaTopicsInitializer {
+
+  private final KafkaAdmin kafkaAdmin;
+  private final BeanFactory beanFactory;
+  private final FolioExecutionContext folioExecutionContext;
+  private final KafkaListenerEndpointRegistry kafkaListenerEndpointRegistry;
+  private final String kafkaEnvId;
+
+  public void createTopics() {
+    if (folioExecutionContext == null) {
+      throw new IllegalStateException("Could be executed on in Folio-request scope");
+    }
+    var tenantId = folioExecutionContext.getTenantId();
+    var topicList = tenantSpecificTopics(tenantId);
+
+    log.info("Creating topics for kafka [topics: {}]", topicList);
+    var configurableBeanFactory = (ConfigurableBeanFactory) beanFactory;
+    topicList.forEach(newTopic -> {
+      var beanName = newTopic.name() + ".topic";
+      if (!configurableBeanFactory.containsBean(beanName)) {
+        configurableBeanFactory.registerSingleton(beanName, newTopic);
+      }
+    });
+    kafkaAdmin.initialize();
+    kafkaListenerEndpointRegistry.getListenerContainers().forEach(messageListenerContainer -> {
+      messageListenerContainer.stop();
+      messageListenerContainer.start();
+    });
+  }
+
+  private List<NewTopic> tenantSpecificTopics(String tenant) {
+    var eventsNameStreamBuilder = Stream.<Enum<?>>builder();
+    for (QmEventTypes qmEventType : QmEventTypes.values()) {
+      eventsNameStreamBuilder.add(qmEventType);
+    }
+    eventsNameStreamBuilder.add(DataImportEventTypes.DI_ERROR);
+    eventsNameStreamBuilder.add(DataImportEventTypes.DI_COMPLETED);
+    return eventsNameStreamBuilder.build()
+      .map(Enum::name)
+      .map(topic -> getTenantTopicName(topic, tenant))
+      .map(this::toKafkaTopic)
+      .collect(Collectors.toList());
+  }
+
+  private NewTopic toKafkaTopic(String topic) {
+    return TopicBuilder.name(topic).build();
+  }
+
+  private String getTenantTopicName(String topicName, String tenantId) {
+    return String.format("%s.Default.%s.%s", kafkaEnvId, tenantId, topicName);
+  }
+}

--- a/src/test/java/org/folio/qm/controller/BaseApiTest.java
+++ b/src/test/java/org/folio/qm/controller/BaseApiTest.java
@@ -54,11 +54,7 @@ import org.folio.tenant.domain.dto.TenantAttributes;
 @ExtendWith(DatabaseExtension.class)
 @ConfigurationPropertiesScan("org.folio.qm.util")
 @ContextConfiguration(initializers = {WireMockInitializer.class})
-@EmbeddedKafka(partitions = 1, topics = {
-  KafkaListenerApiTest.DI_COMPLETE_TOPIC_NAME,
-  KafkaListenerApiTest.DI_ERROR_TOPIC_NAME,
-  KafkaListenerApiTest.QM_COMPLETE_TOPIC_NAME
-})
+@EmbeddedKafka(partitions = 1)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class BaseApiTest {
 


### PR DESCRIPTION
## Purpose
Fix the problem when Kafka listeners didn't subscribe to topics on module initialization

## Approach
* Create Kafka topics on tenant initialization
* Reload Kafka endpoint registry after topic created.