### PR TITLE
MODQM-146 View MARC Holdings via quickMARC

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ quickMARC API provides the following URLs:
 
 |  Method | URL| Permissions  | Description  | 
 |---|---|---|---|
-| GET | /records-editor/records?instanceId={instanceId}  |records-editor.records.item.get   | Retrieves QuickMarc by instance's id  |
+| GET | /records-editor/records?externalId={externalId}  |records-editor.records.item.get   | Retrieves QuickMarc by external id  |
 | POST| /records-editor/records|records-editor.records.item.post| Create a new MARC and Instance records|
 | PUT | /records-editor/records/{recordId}  |records-editor.records.item.get   | Updates SRS record |
 | GET | /records-editor/records/status?qmRecordId={qmRecordId}  |records-editor.records.status.item.get   | Retrieves status of MARC bibliographic record creation  |

--- a/ramls/records-editor.raml
+++ b/ramls/records-editor.raml
@@ -24,11 +24,11 @@ traits:
 /records-editor/records:
   displayName: quickMARC API
   get:
-    description: "Get MARC record by instanceId"
+    description: "Get MARC record by externalId"
     is: [language]
     queryParameters:
       instanceId:
-        description: "UUID of the instance that is related to the MARC record"
+        description: "UUID of the external that is related to the MARC record"
         type: UUID
         required: true
         example: f6c574b5-b1d5-4e5e-a28b-161b7e03e81a

--- a/src/main/java/org/folio/qm/client/SRMChangeManagerClient.java
+++ b/src/main/java/org/folio/qm/client/SRMChangeManagerClient.java
@@ -21,7 +21,7 @@ import org.folio.rest.jaxrs.model.RawRecordsDto;
 public interface SRMChangeManagerClient {
 
   @GetMapping(value = "/parsedRecords", produces = MediaType.APPLICATION_JSON_VALUE)
-  ParsedRecordDto getParsedRecordByInstanceId(@RequestParam("instanceId") String instanceId);
+  ParsedRecordDto getParsedRecordByExternalId(@RequestParam("externalId") String externalId);
 
   @PutMapping(value = "/parsedRecords/{id}")
   void putParsedRecordByInstanceId(@PathVariable("id") String id, ParsedRecordDto recordDto);

--- a/src/main/java/org/folio/qm/controller/RecordsEditorApiImpl.java
+++ b/src/main/java/org/folio/qm/controller/RecordsEditorApiImpl.java
@@ -24,8 +24,8 @@ public class RecordsEditorApiImpl implements RecordsEditorApi {
   private final MarcRecordsService marcRecordsService;
 
   @Override
-  public ResponseEntity<QuickMarc> getRecordByInstanceId(UUID instanceId, String lang) {
-    var quickMarc = marcRecordsService.findByInstanceId(instanceId);
+  public ResponseEntity<QuickMarc> getRecordByExternalId(UUID externalId, String lang) {
+    var quickMarc = marcRecordsService.findByExternalId(externalId);
     return ResponseEntity.ok(quickMarc);
   }
 

--- a/src/main/java/org/folio/qm/converter/ParsedRecordDtoToQuickMarcConverter.java
+++ b/src/main/java/org/folio/qm/converter/ParsedRecordDtoToQuickMarcConverter.java
@@ -83,6 +83,7 @@ public class ParsedRecordDtoToQuickMarcConverter implements Converter<ParsedReco
       fields.sort(QUICK_MARC_FIELDS_COMPARATOR);
 
       return new QuickMarc().parsedRecordId(parsedRecord.getId())
+        .recordType(parsedRecordDto.getRecordType().value())
         .leader(leader)
         .fields(fields)
         .parsedRecordDtoId(parsedRecordDto.getId())

--- a/src/main/java/org/folio/qm/service/MarcRecordsService.java
+++ b/src/main/java/org/folio/qm/service/MarcRecordsService.java
@@ -8,12 +8,12 @@ import org.folio.qm.domain.dto.QuickMarc;
 public interface MarcRecordsService {
 
   /**
-   * This method returns QuickMarc record from SRS by corresponding instance's id
+   * This method returns QuickMarc record from SRS by corresponding external id
    *
-   * @param instanceId instance's id
+   * @param externalId external id
    * @return {@link QuickMarc} record
    */
-  QuickMarc findByInstanceId(UUID instanceId);
+  QuickMarc findByExternalId(UUID externalId);
 
   /**
    * This method updates QuickMarc record

--- a/src/main/java/org/folio/qm/service/ValidationService.java
+++ b/src/main/java/org/folio/qm/service/ValidationService.java
@@ -7,7 +7,7 @@ import org.folio.spring.FolioExecutionContext;
 
 public interface ValidationService {
 
-  void validateIdsMatch(QuickMarc quickMarc, UUID instanceId);
+  void validateIdsMatch(QuickMarc quickMarc, UUID externalId);
 
   void validateQmRecordId(UUID qmRecordId);
 

--- a/src/main/java/org/folio/qm/service/impl/MarcRecordsServiceImpl.java
+++ b/src/main/java/org/folio/qm/service/impl/MarcRecordsServiceImpl.java
@@ -55,8 +55,8 @@ public class MarcRecordsServiceImpl implements MarcRecordsService {
   private final JobExecutionProfileProperties jobExecutionProfileProperties;
 
   @Override
-  public QuickMarc findByInstanceId(UUID instanceId) {
-    var parsedRecordDto = srmClient.getParsedRecordByInstanceId(instanceId.toString());
+  public QuickMarc findByExternalId(UUID externalId) {
+    var parsedRecordDto = srmClient.getParsedRecordByExternalId(externalId.toString());
     var quickMarc = parsedRecordToQuickMarcConverter.convert(parsedRecordDto);
     if (parsedRecordDto.getMetadata() != null && parsedRecordDto.getMetadata().getUpdatedByUserId() != null) {
       usersClient.fetchUserById(parsedRecordDto.getMetadata().getUpdatedByUserId())

--- a/src/main/java/org/folio/qm/service/impl/ValidationServiceImpl.java
+++ b/src/main/java/org/folio/qm/service/impl/ValidationServiceImpl.java
@@ -22,8 +22,8 @@ public class ValidationServiceImpl implements ValidationService {
   public static final String X_OKAPI_TOKEN_USER_ID_IS_MISSING_MESSAGE = "X-Okapi-User-Id header is missing";
 
   @Override
-  public void validateIdsMatch(QuickMarc quickMarc, UUID instanceId) {
-    if (!quickMarc.getParsedRecordId().equals(instanceId.toString())) {
+  public void validateIdsMatch(QuickMarc quickMarc, UUID externalId) {
+    if (!quickMarc.getParsedRecordId().equals(externalId.toString())) {
       var error = buildError(HttpStatus.BAD_REQUEST, ErrorUtils.ErrorType.INTERNAL, REQUEST_AND_ENTITY_ID_NOT_EQUAL_MESSAGE);
       throw new ValidationException(error);
     }

--- a/src/main/resources/swagger.api/records-editor.yaml
+++ b/src/main/resources/swagger.api/records-editor.yaml
@@ -37,13 +37,13 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/error"
-      description: Get MARC record by instanceId
-      operationId: getRecordByInstanceId
+      description: Get MARC record by externalId
+      operationId: getRecordByExternalId
       parameters:
-        - name: instanceId
+        - name: externalId
           in: query
           required: true
-          description: UUID of the instance that is related to the MARC record
+          description: UUID of the external that is related to the MARC record
           schema:
             $ref: "#/components/schemas/UUID"
         - name: lang

--- a/src/main/resources/swagger.api/schemas/quickMarcJson.json
+++ b/src/main/resources/swagger.api/schemas/quickMarcJson.json
@@ -31,6 +31,11 @@
       "$ref": "#/$defs/uuid",
       "example": "b9a5f035-de63-4e2c-92c2-07240c89b817"
     },
+    "recordType": {
+      "description": "Type of record, e.g. MARC",
+      "type": "string",
+      "example": "MARC_BIB"
+    },
     "leader": {
       "description": "Leader record",
       "type": "string",

--- a/src/test/java/org/folio/qm/controller/RecordsEditorApiTest.java
+++ b/src/test/java/org/folio/qm/controller/RecordsEditorApiTest.java
@@ -23,7 +23,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.folio.qm.utils.APITestUtils.CHANGE_MANAGER_JOB_EXECUTION_PATH;
 import static org.folio.qm.utils.APITestUtils.CHANGE_MANAGER_JOB_PROFILE_PATH;
 import static org.folio.qm.utils.APITestUtils.CHANGE_MANAGER_PARSE_RECORDS_PATH;
-import static org.folio.qm.utils.APITestUtils.INSTANCE_ID;
+import static org.folio.qm.utils.APITestUtils.EXTERNAL_ID;
 import static org.folio.qm.utils.APITestUtils.JOHN_USER_ID_HEADER;
 import static org.folio.qm.utils.APITestUtils.QM_RECORD_ID;
 import static org.folio.qm.utils.APITestUtils.changeManagerPath;
@@ -39,7 +39,7 @@ import static org.folio.qm.utils.DBTestUtils.saveCreationStatus;
 import static org.folio.qm.utils.IOTestUtils.readFile;
 import static org.folio.qm.utils.JsonTestUtils.getObjectFromJson;
 import static org.folio.qm.utils.JsonTestUtils.readQuickMarc;
-import static org.folio.qm.utils.testentities.TestEntitiesUtils.EXISTED_INSTANCE_ID;
+import static org.folio.qm.utils.testentities.TestEntitiesUtils.EXISTED_EXTERNAL_ID;
 import static org.folio.qm.utils.testentities.TestEntitiesUtils.JOHN_USER_ID;
 import static org.folio.qm.utils.testentities.TestEntitiesUtils.PARSED_RECORD_DTO_PATH;
 import static org.folio.qm.utils.testentities.TestEntitiesUtils.QM_EDITED_RECORD_PATH;
@@ -72,14 +72,14 @@ class RecordsEditorApiTest extends BaseApiTest {
   void testGetQuickMarcRecord() {
     log.info("===== Verify GET record: Successful =====");
 
-    mockGet(changeManagerPath(INSTANCE_ID, EXISTED_INSTANCE_ID), readFile(PARSED_RECORD_DTO_PATH), SC_OK,
+    mockGet(changeManagerPath(EXTERNAL_ID, EXISTED_EXTERNAL_ID), readFile(PARSED_RECORD_DTO_PATH), SC_OK,
       wireMockServer);
     mockGet(usersByIdPath(JOHN_USER_ID), readFile(USER_JOHN_PATH), SC_OK, wireMockServer);
 
-    var quickMarcJson = verifyGet(recordsEditorPath(INSTANCE_ID, EXISTED_INSTANCE_ID), SC_OK).as(QuickMarc.class);
+    var quickMarcJson = verifyGet(recordsEditorPath(EXTERNAL_ID, EXISTED_EXTERNAL_ID), SC_OK).as(QuickMarc.class);
 
     assertThat(quickMarcJson.getParsedRecordDtoId(), equalTo(VALID_PARSED_RECORD_DTO_ID));
-    assertThat(quickMarcJson.getInstanceId(), equalTo(EXISTED_INSTANCE_ID));
+    assertThat(quickMarcJson.getInstanceId(), equalTo(EXISTED_EXTERNAL_ID));
     assertThat(quickMarcJson.getSuppressDiscovery(), equalTo(Boolean.FALSE));
     assertThat(quickMarcJson.getParsedRecordId(), equalTo(VALID_PARSED_RECORD_ID));
     assertThat(quickMarcJson.getUpdateInfo().getUpdatedBy().getUserId(), equalTo(JOHN_USER_ID));
@@ -95,9 +95,9 @@ class RecordsEditorApiTest extends BaseApiTest {
 
     String recordNotFoundId = UUID.randomUUID().toString();
 
-    mockGet(changeManagerPath(INSTANCE_ID, recordNotFoundId), "Not found", SC_NOT_FOUND, wireMockServer);
+    mockGet(changeManagerPath(EXTERNAL_ID, recordNotFoundId), "Not found", SC_NOT_FOUND, wireMockServer);
 
-    Error error = verifyGet(recordsEditorPath(INSTANCE_ID, recordNotFoundId), SC_NOT_FOUND).as(Error.class);
+    Error error = verifyGet(recordsEditorPath(EXTERNAL_ID, recordNotFoundId), SC_NOT_FOUND).as(Error.class);
 
     assertThat(error.getType(), equalTo(ErrorUtils.ErrorType.FOLIO_EXTERNAL_OR_UNDEFINED.getTypeCode()));
     assertThat(wireMockServer.getAllServeEvents(), hasSize(1));
@@ -109,9 +109,9 @@ class RecordsEditorApiTest extends BaseApiTest {
 
     String instanceId = UUID.randomUUID().toString();
 
-    mockGet(changeManagerPath(INSTANCE_ID, instanceId), "{}", SC_OK, wireMockServer);
+    mockGet(changeManagerPath(EXTERNAL_ID, instanceId), "{}", SC_OK, wireMockServer);
 
-    Error error = verifyGet(recordsEditorPath(INSTANCE_ID, instanceId), SC_UNPROCESSABLE_ENTITY).as(Error.class);
+    Error error = verifyGet(recordsEditorPath(EXTERNAL_ID, instanceId), SC_UNPROCESSABLE_ENTITY).as(Error.class);
     assertThat(error.getType(), equalTo(ErrorUtils.ErrorType.INTERNAL.getTypeCode()));
 
     assertThat(wireMockServer.getAllServeEvents(), hasSize(1));
@@ -206,7 +206,7 @@ class RecordsEditorApiTest extends BaseApiTest {
 
     QuickMarc quickMarcJson = readQuickMarc(QM_EDITED_RECORD_PATH)
       .parsedRecordDtoId(VALID_PARSED_RECORD_DTO_ID)
-      .instanceId(EXISTED_INSTANCE_ID);
+      .instanceId(EXISTED_EXTERNAL_ID);
 
     String jobExecution = "mockdata/change-manager/job-execution/jobExecutionCreated.json";
     mockPost(CHANGE_MANAGER_JOB_EXECUTION_PATH, jobExecution, wireMockServer);
@@ -244,7 +244,7 @@ class RecordsEditorApiTest extends BaseApiTest {
 
     QuickMarc quickMarcJson = readQuickMarc(QM_EDITED_RECORD_PATH)
       .parsedRecordDtoId(VALID_PARSED_RECORD_DTO_ID)
-      .instanceId(EXISTED_INSTANCE_ID);
+      .instanceId(EXISTED_EXTERNAL_ID);
 
     String jobExecution = "mockdata/change-manager/job-execution/jobExecution_invalid_user_id.json";
     mockPost(CHANGE_MANAGER_JOB_EXECUTION_PATH, jobExecution, SC_UNPROCESSABLE_ENTITY, wireMockServer);
@@ -261,7 +261,7 @@ class RecordsEditorApiTest extends BaseApiTest {
 
     QuickMarc quickMarcJson = readQuickMarc(QM_EDITED_RECORD_PATH)
       .parsedRecordDtoId(VALID_PARSED_RECORD_DTO_ID)
-      .instanceId(EXISTED_INSTANCE_ID);
+      .instanceId(EXISTED_EXTERNAL_ID);
 
     final var error = verifyPost(recordsEditorPath(), quickMarcJson, SC_BAD_REQUEST).as(Error.class);
     assertThat(error.getMessage(), equalTo("X-Okapi-User-Id header is missing"));
@@ -273,7 +273,7 @@ class RecordsEditorApiTest extends BaseApiTest {
 
     QuickMarc quickMarcJson = readQuickMarc(QM_EDITED_RECORD_PATH)
       .parsedRecordDtoId(VALID_PARSED_RECORD_DTO_ID)
-      .instanceId(EXISTED_INSTANCE_ID);
+      .instanceId(EXISTED_EXTERNAL_ID);
 
     wireMockServer.stubFor(post(urlEqualTo(CHANGE_MANAGER_JOB_EXECUTION_PATH))
       .willReturn(aResponse()

--- a/src/test/java/org/folio/qm/controller/RecordsEditorAsyncApiTest.java
+++ b/src/test/java/org/folio/qm/controller/RecordsEditorAsyncApiTest.java
@@ -21,7 +21,7 @@ import static org.folio.qm.utils.APITestUtils.mockPut;
 import static org.folio.qm.utils.APITestUtils.recordsEditorResourceByIdPath;
 import static org.folio.qm.utils.JsonTestUtils.getObjectAsJson;
 import static org.folio.qm.utils.JsonTestUtils.readQuickMarc;
-import static org.folio.qm.utils.testentities.TestEntitiesUtils.EXISTED_INSTANCE_ID;
+import static org.folio.qm.utils.testentities.TestEntitiesUtils.EXISTED_EXTERNAL_ID;
 import static org.folio.qm.utils.testentities.TestEntitiesUtils.JOHN_USER_ID;
 import static org.folio.qm.utils.testentities.TestEntitiesUtils.QM_LEADER_MISMATCH1;
 import static org.folio.qm.utils.testentities.TestEntitiesUtils.QM_LEADER_MISMATCH2;
@@ -63,7 +63,7 @@ public class RecordsEditorAsyncApiTest extends BaseApiTest {
 
     QuickMarc quickMarcJson = readQuickMarc(QM_RECORD_PATH)
       .parsedRecordDtoId(VALID_PARSED_RECORD_DTO_ID)
-      .instanceId(EXISTED_INSTANCE_ID);
+      .instanceId(EXISTED_EXTERNAL_ID);
 
     MvcResult result = mockMvc.perform(put(recordsEditorResourceByIdPath(VALID_PARSED_RECORD_ID))
       .headers(defaultHeaders())
@@ -88,7 +88,7 @@ public class RecordsEditorAsyncApiTest extends BaseApiTest {
 
     QuickMarc quickMarcJson = readQuickMarc(QM_RECORD_PATH)
       .parsedRecordDtoId(VALID_PARSED_RECORD_DTO_ID)
-      .instanceId(EXISTED_INSTANCE_ID);
+      .instanceId(EXISTED_EXTERNAL_ID);
 
     MvcResult result = mockMvc.perform(put(recordsEditorResourceByIdPath(VALID_PARSED_RECORD_ID))
       .headers(defaultHeaders())
@@ -116,7 +116,7 @@ public class RecordsEditorAsyncApiTest extends BaseApiTest {
 
     QuickMarc quickMarcJson = readQuickMarc(QM_RECORD_PATH)
       .parsedRecordDtoId(wrongUUID)
-      .instanceId(EXISTED_INSTANCE_ID);
+      .instanceId(EXISTED_EXTERNAL_ID);
 
     wireMockServer.verify(exactly(0), putRequestedFor(urlEqualTo(changeManagerResourceByIdPath(wrongUUID))));
 
@@ -134,7 +134,7 @@ public class RecordsEditorAsyncApiTest extends BaseApiTest {
 
     QuickMarc quickMarcJson = readQuickMarc(QM_RECORD_PATH)
       .parsedRecordDtoId(VALID_PARSED_RECORD_DTO_ID)
-      .instanceId(EXISTED_INSTANCE_ID);
+      .instanceId(EXISTED_EXTERNAL_ID);
 
     mockMvc.perform(put(recordsEditorResourceByIdPath(VALID_PARSED_RECORD_DTO_ID))
       .headers(defaultHeaders())
@@ -154,7 +154,7 @@ public class RecordsEditorAsyncApiTest extends BaseApiTest {
 
     QuickMarc quickMarcJson = readQuickMarc(QM_RECORD_WITH_INCORRECT_TAG_PATH)
       .parsedRecordDtoId(VALID_PARSED_RECORD_DTO_ID)
-      .instanceId(EXISTED_INSTANCE_ID);
+      .instanceId(EXISTED_EXTERNAL_ID);
 
     mockMvc.perform(put(recordsEditorResourceByIdPath(VALID_PARSED_RECORD_ID))
       .headers(defaultHeaders())
@@ -211,7 +211,7 @@ public class RecordsEditorAsyncApiTest extends BaseApiTest {
 
     QuickMarc quickMarcJson = readQuickMarc(QM_WRONG_ITEM_LENGTH)
       .parsedRecordDtoId(VALID_PARSED_RECORD_DTO_ID)
-      .instanceId(EXISTED_INSTANCE_ID);
+      .instanceId(EXISTED_EXTERNAL_ID);
 
     mockMvc.perform(put(recordsEditorResourceByIdPath(VALID_PARSED_RECORD_ID))
       .headers(defaultHeaders())
@@ -232,7 +232,7 @@ public class RecordsEditorAsyncApiTest extends BaseApiTest {
 
     QuickMarc quickMarcJson = readQuickMarc(filename)
       .parsedRecordDtoId(VALID_PARSED_RECORD_DTO_ID)
-      .instanceId(EXISTED_INSTANCE_ID);
+      .instanceId(EXISTED_EXTERNAL_ID);
 
     mockMvc.perform(put(recordsEditorResourceByIdPath(VALID_PARSED_RECORD_ID))
       .headers(defaultHeaders())

--- a/src/test/java/org/folio/qm/service/impl/MarcRecordsServiceImplTest.java
+++ b/src/test/java/org/folio/qm/service/impl/MarcRecordsServiceImplTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
 import static org.folio.qm.utils.JsonTestUtils.readQuickMarc;
-import static org.folio.qm.utils.testentities.TestEntitiesUtils.EXISTED_INSTANCE_ID;
+import static org.folio.qm.utils.testentities.TestEntitiesUtils.EXISTED_EXTERNAL_ID;
 import static org.folio.qm.utils.testentities.TestEntitiesUtils.QM_EMPTY_FIELDS;
 import static org.folio.qm.utils.testentities.TestEntitiesUtils.VALID_JOB_EXECUTION_ID;
 import static org.folio.qm.utils.testentities.TestEntitiesUtils.VALID_PARSED_RECORD_DTO_ID;
@@ -95,7 +95,7 @@ class MarcRecordsServiceImplTest {
 
     var quickMarcJson = readQuickMarc(QM_EMPTY_FIELDS)
       .parsedRecordDtoId(VALID_PARSED_RECORD_DTO_ID)
-      .instanceId(EXISTED_INSTANCE_ID);
+      .instanceId(EXISTED_EXTERNAL_ID);
 
     final Predicate<QuickMarcFields> field999Predicate = qmFields -> qmFields.getTag().equals("999");
     final Predicate<QuickMarcFields> emptyContentPredicate =  qmFields -> {

--- a/src/test/java/org/folio/qm/utils/APITestUtils.java
+++ b/src/test/java/org/folio/qm/utils/APITestUtils.java
@@ -33,7 +33,7 @@ public class APITestUtils {
   public static final String CHANGE_MANAGER_PARSE_RECORDS_PATH = CHANGE_MANAGER_JOB_EXECUTION_PATH + "/%s/records";
   public static final String USERS_PATH = "/users";
 
-  public static final String INSTANCE_ID = "instanceId";
+  public static final String EXTERNAL_ID = "externalId";
   public static final String QM_RECORD_ID = "qmRecordId";
 
   public static final Header JOHN_USER_ID_HEADER = new Header(USER_ID, JOHN_USER_ID);

--- a/src/test/java/org/folio/qm/utils/testentities/TestEntitiesUtils.java
+++ b/src/test/java/org/folio/qm/utils/testentities/TestEntitiesUtils.java
@@ -34,7 +34,7 @@ public class TestEntitiesUtils {
 
   public static final String TESTED_TAG_NAME = "333";
   public static final String VALID_PARSED_RECORD_DTO_ID = "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c";
-  public static final String EXISTED_INSTANCE_ID = "b9a5f035-de63-4e2c-92c2-07240c89b817";
+  public static final String EXISTED_EXTERNAL_ID = "b9a5f035-de63-4e2c-92c2-07240c89b817";
   public static final String VALID_PARSED_RECORD_ID = "c9db5d7a-e1d4-11e8-9f32-f2801f1b9fd1";
   public static final String VALID_JOB_EXECUTION_ID = "a7fb1c32-1ffb-4a22-a76a-4067284fe68d";
   public static final UUID JOB_EXECUTION_ID = UUID.fromString(VALID_JOB_EXECUTION_ID);
@@ -57,7 +57,7 @@ public class TestEntitiesUtils {
     return new ParsedRecordDto()
       .withId(VALID_PARSED_RECORD_DTO_ID)
       .withParsedRecord(parsedRecord)
-      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(EXISTED_INSTANCE_ID))
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(EXISTED_EXTERNAL_ID))
       .withAdditionalInfo(new AdditionalInfo().withSuppressDiscovery(false)).withRecordType(RecordType.MARC_BIB)
       .withRecordState(ParsedRecordDto.RecordState.ACTUAL)
       .withMetadata(new Metadata()

--- a/src/test/resources/mockdata/quick-marc-json/books.json
+++ b/src/test/resources/mockdata/quick-marc-json/books.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00157caa\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/books_missing_items.json
+++ b/src/test/resources/mockdata/quick-marc-json/books_missing_items.json
@@ -1,8 +1,9 @@
 {
   "parsedRecordId": "c9db5d7a-e1d4-11e8-9f32-f2801f1b9fd1",
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
-  "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
   "suppressDiscovery": false,
+  "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00157caa\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/continuing.json
+++ b/src/test/resources/mockdata/quick-marc-json/continuing.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00157csb\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/descriptions/electronic_resource.json
+++ b/src/test/resources/mockdata/quick-marc-json/descriptions/electronic_resource.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00071caa\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/descriptions/electronic_resource_missing_items.json
+++ b/src/test/resources/mockdata/quick-marc-json/descriptions/electronic_resource_missing_items.json
@@ -1,8 +1,9 @@
 {
   "parsedRecordId": "c9db5d7a-e1d4-11e8-9f32-f2801f1b9fd1",
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
-  "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
   "suppressDiscovery": false,
+  "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00052caa\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/descriptions/globe.json
+++ b/src/test/resources/mockdata/quick-marc-json/descriptions/globe.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00063caa\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/descriptions/kit.json
+++ b/src/test/resources/mockdata/quick-marc-json/descriptions/kit.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00059caa\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/descriptions/map.json
+++ b/src/test/resources/mockdata/quick-marc-json/descriptions/map.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00065caa\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/descriptions/microform.json
+++ b/src/test/resources/mockdata/quick-marc-json/descriptions/microform.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00070caa\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/descriptions/motion_picture.json
+++ b/src/test/resources/mockdata/quick-marc-json/descriptions/motion_picture.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00080caa\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/descriptions/nonprojected_graphic.json
+++ b/src/test/resources/mockdata/quick-marc-json/descriptions/nonprojected_graphic.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00063caa\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/descriptions/notated_music.json
+++ b/src/test/resources/mockdata/quick-marc-json/descriptions/notated_music.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00059caa\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/descriptions/projected_graphic.json
+++ b/src/test/resources/mockdata/quick-marc-json/descriptions/projected_graphic.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00066caa\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/descriptions/remote_sensing_image.json
+++ b/src/test/resources/mockdata/quick-marc-json/descriptions/remote_sensing_image.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00068caa\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/descriptions/sound_recording.json
+++ b/src/test/resources/mockdata/quick-marc-json/descriptions/sound_recording.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00071caa\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/descriptions/tactile_material.json
+++ b/src/test/resources/mockdata/quick-marc-json/descriptions/tactile_material.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00067caa\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/descriptions/text.json
+++ b/src/test/resources/mockdata/quick-marc-json/descriptions/text.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00059caa\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/descriptions/unknown.json
+++ b/src/test/resources/mockdata/quick-marc-json/descriptions/unknown.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00084caa\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/descriptions/unspecified.json
+++ b/src/test/resources/mockdata/quick-marc-json/descriptions/unspecified.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00059caa\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/descriptions/videorecording.json
+++ b/src/test/resources/mockdata/quick-marc-json/descriptions/videorecording.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00066caa\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/files.json
+++ b/src/test/resources/mockdata/quick-marc-json/files.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00157cma\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/maps.json
+++ b/src/test/resources/mockdata/quick-marc-json/maps.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00157cea\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/mixed.json
+++ b/src/test/resources/mockdata/quick-marc-json/mixed.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00157cpc\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/quickMarcJson.json
+++ b/src/test/resources/mockdata/quick-marc-json/quickMarcJson.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "01706ccm\\a2200361\\\\ 4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/quickMarcJsonLeaderMismatchMissing008Value.json
+++ b/src/test/resources/mockdata/quick-marc-json/quickMarcJsonLeaderMismatchMissing008Value.json
@@ -1,8 +1,9 @@
 {
   "parsedRecordId": "c9db5d7a-e1d4-11e8-9f32-f2801f1b9fd1",
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
-  "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
   "suppressDiscovery": false,
+  "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "01587ccm a2200361   4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/quickMarcJsonLeaderMismatchValueMismatch.json
+++ b/src/test/resources/mockdata/quick-marc-json/quickMarcJsonLeaderMismatchValueMismatch.json
@@ -1,8 +1,9 @@
 {
   "parsedRecordId": "c9db5d7a-e1d4-11e8-9f32-f2801f1b9fd1",
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
-  "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
   "suppressDiscovery": false,
+  "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "01587ccm a2200361   4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/quickMarcJsonMissingWhitespaces.json
+++ b/src/test/resources/mockdata/quick-marc-json/quickMarcJsonMissingWhitespaces.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "a5f283d6-665b-4482-8b29-07140495a7f0",
   "suppressDiscovery": false,
   "instanceId": "02df6658-c639-41f2-8587-1ec44dd43d8e",
+  "recordType": "MARC_BIB",
   "leader": "03522nam\\a22004331i\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/quickMarcJsonWrongItemLength.json
+++ b/src/test/resources/mockdata/quick-marc-json/quickMarcJsonWrongItemLength.json
@@ -1,8 +1,9 @@
 {
   "parsedRecordId": "c9db5d7a-e1d4-11e8-9f32-f2801f1b9fd1",
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
-  "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
   "suppressDiscovery": false,
+  "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "01587ccm\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/quickMarcJson_edited.json
+++ b/src/test/resources/mockdata/quick-marc-json/quickMarcJson_edited.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "01706ccm\\a2200361\\\\ 4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/quickMarcJson_emptyContent.json
+++ b/src/test/resources/mockdata/quick-marc-json/quickMarcJson_emptyContent.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "01706ccm\\a2200361\\\\ 4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/quickMarcJson_withIncorrectTag.json
+++ b/src/test/resources/mockdata/quick-marc-json/quickMarcJson_withIncorrectTag.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "01706ccm\\a2200361\\\\ 4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/scores.json
+++ b/src/test/resources/mockdata/quick-marc-json/scores.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00157cca\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/sound.json
+++ b/src/test/resources/mockdata/quick-marc-json/sound.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00157cia\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/unknown.json
+++ b/src/test/resources/mockdata/quick-marc-json/unknown.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00157cha\\a2200361\\\\\\4500",
   "fields": [
     {

--- a/src/test/resources/mockdata/quick-marc-json/visual.json
+++ b/src/test/resources/mockdata/quick-marc-json/visual.json
@@ -3,6 +3,7 @@
   "parsedRecordDtoId": "c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c",
   "suppressDiscovery": false,
   "instanceId": "b9a5f035-de63-4e2c-92c2-07240c89b817",
+  "recordType": "MARC_BIB",
   "leader": "00157cga\\a2200361\\\\\\4500",
   "fields": [
     {


### PR DESCRIPTION
## Purpose
Update GET /change-manager/parsedRecords  to have externalId param instead instanceId. It will give quick-marc an ability to fetch records by its externalId from SRS.

## Approach
- replace required `instanceId` query parameter with `externalId`
- update existing logic of retrieve record from SRM
- update converting SRM->quickMarc logic

## Learning
[MODQM-146](https://issues.folio.org/browse/MODQM-146)
