### PR TITLE
MODQM-162 Can't deserialize events from data import

### DIFF
--- a/src/main/java/org/folio/qm/messaging/deserializer/DataImportEventDeserializer.java
+++ b/src/main/java/org/folio/qm/messaging/deserializer/DataImportEventDeserializer.java
@@ -20,7 +20,7 @@ public class DataImportEventDeserializer implements Deserializer<DataImportEvent
   @Override
   public DataImportEventPayload deserialize(String topic, byte[] data) {
     try {
-      var eventPayload = objectMapper.readTree(data).get("eventPayload").toString();
+      var eventPayload = objectMapper.readTree(data).get("eventPayload").asText();
       return objectMapper.readValue(eventPayload, DataImportEventPayload.class);
     } catch (IOException e) {
       throw new SerializationException("Can't deserialize data [" + Arrays.toString(data) +

--- a/src/main/java/org/folio/qm/messaging/deserializer/DataImportEventDeserializer.java
+++ b/src/main/java/org/folio/qm/messaging/deserializer/DataImportEventDeserializer.java
@@ -9,7 +9,6 @@ import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.springframework.stereotype.Component;
 
-import org.folio.qm.util.ZIPArchiver;
 import org.folio.rest.jaxrs.model.DataImportEventPayload;
 
 @Component
@@ -22,7 +21,7 @@ public class DataImportEventDeserializer implements Deserializer<DataImportEvent
   public DataImportEventPayload deserialize(String topic, byte[] data) {
     try {
       var eventPayload = objectMapper.readTree(data).get("eventPayload").asText();
-      return objectMapper.readValue(ZIPArchiver.unzip(eventPayload), DataImportEventPayload.class);
+      return objectMapper.readValue(eventPayload, DataImportEventPayload.class);
     } catch (IOException e) {
       throw new SerializationException("Can't deserialize data [" + Arrays.toString(data) +
         "] from topic [" + topic + "]", e);

--- a/src/main/java/org/folio/qm/messaging/deserializer/DataImportEventDeserializer.java
+++ b/src/main/java/org/folio/qm/messaging/deserializer/DataImportEventDeserializer.java
@@ -20,7 +20,7 @@ public class DataImportEventDeserializer implements Deserializer<DataImportEvent
   @Override
   public DataImportEventPayload deserialize(String topic, byte[] data) {
     try {
-      var eventPayload = objectMapper.readTree(data).get("eventPayload").asText();
+      var eventPayload = objectMapper.readTree(data).get("eventPayload").toString();
       return objectMapper.readValue(eventPayload, DataImportEventPayload.class);
     } catch (IOException e) {
       throw new SerializationException("Can't deserialize data [" + Arrays.toString(data) +

--- a/src/test/java/org/folio/qm/controller/BaseApiTest.java
+++ b/src/test/java/org/folio/qm/controller/BaseApiTest.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.internals.RecordHeader;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -158,10 +159,11 @@ class BaseApiTest {
       .response();
   }
 
+  @SneakyThrows
   protected void sendDIKafkaRecord(String eventPayloadFilePath, String topicName) {
-    String message = String.format("{"
-      + "\"eventPayload\": %s"
-      + "}", readFile(eventPayloadFilePath));
+    var jsonObject = new JSONObject();
+    jsonObject.put("eventPayload", readFile(eventPayloadFilePath));
+    String message = jsonObject.toString();
     sendKafkaRecord(message, topicName);
   }
 

--- a/src/test/java/org/folio/qm/controller/BaseApiTest.java
+++ b/src/test/java/org/folio/qm/controller/BaseApiTest.java
@@ -43,7 +43,6 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import org.folio.qm.extension.DatabaseExtension;
 import org.folio.qm.extension.WireMockInitializer;
-import org.folio.qm.util.ZIPArchiver;
 import org.folio.spring.FolioModuleMetadata;
 import org.folio.spring.integration.XOkapiHeaders;
 import org.folio.tenant.domain.dto.TenantAttributes;
@@ -159,10 +158,10 @@ class BaseApiTest {
       .response();
   }
 
-  protected void sendDIKafkaRecord(String eventPayloadFilePath, String topicName) throws IOException {
+  protected void sendDIKafkaRecord(String eventPayloadFilePath, String topicName) {
     String message = String.format("{"
-      + "\"eventPayload\": \"%s\""
-      + "}", ZIPArchiver.zip(readFile(eventPayloadFilePath)));
+      + "\"eventPayload\": %s"
+      + "}", readFile(eventPayloadFilePath));
     sendKafkaRecord(message, topicName);
   }
 


### PR DESCRIPTION
## Purpose
Quick MARC can't deserialize event from data import. Data import no longer uses the zip mechanism.

## Approach
removed unzipping from DataImportEventDeserializer

## Learning
https://issues.folio.org/browse/MODQM-162
