### PR TITLE
MODQM-178 Update return 409 if optimistic locking error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ### Changes
 * [MODQM-167](https://issues.folio.org/browse/MODQM-167) - Optimistic locking: mod-quick-marc modifications
+* [MODQM-178](https://issues.folio.org/browse/MODQM-178) - Optimistic locking: Update return 409 if optimistic locking error
 
 ## 2.2.0 - Released 
 

--- a/src/main/java/org/folio/qm/controller/ErrorHandling.java
+++ b/src/main/java/org/folio/qm/controller/ErrorHandling.java
@@ -12,6 +12,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.validation.ConstraintViolationException;
 
 import feign.FeignException;
+import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -29,6 +30,7 @@ import org.folio.spring.exception.NotFoundException;
 import org.folio.tenant.domain.dto.Error;
 import org.folio.tenant.domain.dto.Errors;
 
+@Log4j2
 @RestControllerAdvice
 public class ErrorHandling {
 
@@ -114,6 +116,7 @@ public class ErrorHandling {
   @ExceptionHandler(Exception.class)
   @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
   public Error handleGlobalException(Exception e) {
+    log.error("Unexpected error occurred: ", e);
     return buildError(HttpStatus.INTERNAL_SERVER_ERROR, UNKNOWN, e.getMessage());
   }
 

--- a/src/main/java/org/folio/qm/messaging/listener/QuickMarcEventListener.java
+++ b/src/main/java/org/folio/qm/messaging/listener/QuickMarcEventListener.java
@@ -1,7 +1,11 @@
 package org.folio.qm.messaging.listener;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -10,6 +14,7 @@ import org.springframework.web.context.request.async.DeferredResult;
 import org.folio.qm.messaging.domain.QmCompletedEventPayload;
 import org.folio.qm.service.CacheService;
 import org.folio.qm.util.ErrorUtils;
+import org.folio.tenant.domain.dto.Error;
 
 @Log4j2
 @Component
@@ -18,11 +23,12 @@ import org.folio.qm.util.ErrorUtils;
 public class QuickMarcEventListener {
 
   private final CacheService<DeferredResult> cacheService;
+  private final ObjectMapper objectMapper;
 
   @KafkaListener(groupId = "#{@groupIdProvider.qmCompletedGroupId()}",
     topicPattern = "#{@topicPatternProvider.qmCompletedTopicName()}",
     containerFactory = "quickMarcKafkaListenerContainerFactory")
-  public void qmCompletedListener(QmCompletedEventPayload data) {
+  public void qmCompletedListener(QmCompletedEventPayload data) throws JsonProcessingException {
     var recordId = data.getRecordId();
     log.info("QM_COMPLETED received for record id [{}]", recordId);
     DeferredResult deferredResult = cacheService.getFromCache(String.valueOf(recordId));
@@ -30,10 +36,33 @@ public class QuickMarcEventListener {
       if (data.isSucceed()) {
         deferredResult.setResult(ResponseEntity.accepted().build());
       } else {
-        var error = ErrorUtils.buildError(ErrorUtils.ErrorType.EXTERNAL_OR_UNDEFINED, data.getErrorMessage());
-        deferredResult.setErrorResult(ResponseEntity.badRequest().body(error));
+        var errorMessage = data.getErrorMessage();
+        if (isOptimisticLockingError(errorMessage)) {
+          deferredResult.setErrorResult(buildOptimisticLockingErrorResponse(errorMessage));
+        } else {
+          ResponseEntity<Error> body = buildCommonErrorResponse(errorMessage);
+          deferredResult.setErrorResult(body);
+        }
       }
       cacheService.invalidate(String.valueOf(recordId));
     }
+  }
+
+  @NotNull
+  private ResponseEntity<Error> buildCommonErrorResponse(String errorMessage) {
+    var error = ErrorUtils.buildError(ErrorUtils.ErrorType.EXTERNAL_OR_UNDEFINED, errorMessage);
+    return ResponseEntity.badRequest().body(error);
+  }
+
+  @NotNull
+  private ResponseEntity<Error> buildOptimisticLockingErrorResponse(String errorMessage) throws JsonProcessingException {
+    var errorNode = objectMapper.readTree(errorMessage);
+    var message = errorNode.get("message").asText();
+    var error = ErrorUtils.buildError(ErrorUtils.ErrorType.EXTERNAL_OR_UNDEFINED, message);
+    return ResponseEntity.status(HttpStatus.CONFLICT).body(error);
+  }
+
+  private boolean isOptimisticLockingError(String errorMessage) {
+    return errorMessage.contains("(optimistic locking)");
   }
 }

--- a/src/main/resources/swagger.api/records-editor-async.yaml
+++ b/src/main/resources/swagger.api/records-editor-async.yaml
@@ -21,6 +21,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/error"
+        "409":
+          description: Update failed due to optimistic locking
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
         "500":
           description: Internal server error, e.g. due to misconfiguration
           content:

--- a/src/test/java/org/folio/qm/controller/RecordsEditorAsyncApiTest.java
+++ b/src/test/java/org/folio/qm/controller/RecordsEditorAsyncApiTest.java
@@ -101,6 +101,39 @@ public class RecordsEditorAsyncApiTest extends BaseApiTest {
   }
 
   @Test
+  void testUpdateQuickMarcRecordFailedInEventByOptimisticLocking() throws Exception {
+    RecordsEditorAsyncApiTest.log.info("==== Verify PUT record: Failed in external modules due to optimistic locking ====");
+
+    mockPut(changeManagerResourceByIdPath(VALID_PARSED_RECORD_DTO_ID), SC_ACCEPTED, wireMockServer);
+
+    QuickMarc quickMarcJson = readQuickMarc(QM_RECORD_BIB_PATH)
+      .parsedRecordDtoId(VALID_PARSED_RECORD_DTO_ID)
+      .externalId(EXISTED_EXTERNAL_ID);
+
+    MvcResult result = mockMvc.perform(put(recordsEditorResourceByIdPath(VALID_PARSED_RECORD_ID))
+        .headers(defaultHeaders())
+        .contentType(APPLICATION_JSON)
+        .content(getObjectAsJson(quickMarcJson)))
+      .andExpect(request().asyncStarted())
+      .andReturn();
+
+    var optimisticLockingErrorMessage = "{ \"message\": \"Cannot update record 4f531857-a91d-433a-99ae-0372cecd07d8 because "
+      + "it has been changed (optimistic locking): Stored _version is 9, _version of request is 8\", \"severity\": "
+      + "\"ERROR\", \"code\": \"23F09\", \"where\": \"PL/pgSQL function instance_set_ol_version() line 8 at RAISE\", "
+      + "\"file\": \"pl_exec.c\", \"line\": \"3855\", \"routine\": \"exec_stmt_raise\", \"schema\": "
+      + "\"diku_mod_inventory_storage\", \"table\": \"instance\" }";
+    var expectedErrorMessage = "Cannot update record 4f531857-a91d-433a-99ae-0372cecd07d8 because"
+      + " it has been changed (optimistic locking): Stored _version is 9, _version of request is 8";
+    String eventPayload = createPayload(optimisticLockingErrorMessage);
+    sendQMKafkaRecord(eventPayload, QM_COMPLETE_TOPIC_NAME);
+    mockMvc
+      .perform(asyncDispatch(result))
+      .andExpect(status().isConflict())
+      .andDo(log())
+      .andExpect(errorMessageMatch(equalTo(expectedErrorMessage)));
+  }
+
+  @Test
   void testUpdateQuickMarcRecordWrongUuid() throws Exception {
     RecordsEditorAsyncApiTest.log.info("===== Verify PUT record: Not found =====");
     UUID wrongUUID = UUID.randomUUID();


### PR DESCRIPTION
## Purpose
Update of record returns 409  status if optimistic locking error occurred.

## Approach
* Add to API with 409 status
* Add logging for unexpected errors
* Detect optimistic error message