### PR TITLE
MODQM-181 Kiwi R3 2021 - Log4j vulnerability verification and correction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 2.3.0 2021-11-xx
+* [MODQM-181](https://issues.folio.org/browse/MODQM-181) - Kiwi R3 2021 - Log4j vulnerability verification and correction
 
 ### Changes
 * [MODQM-167](https://issues.folio.org/browse/MODQM-167) - Optimistic locking: mod-quick-marc modifications

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <mockito.version>4.0.0</mockito.version>
     <mapstruct.version>1.4.2.Final</mapstruct.version>
     <commons-lang.version>2.6</commons-lang.version>
+    <log4j2.version>2.16.0</log4j2.version>
 
     <sonar.exclusions>
       src/main/java/org/folio/qm/domain/entity/**,
@@ -51,6 +52,7 @@
   </properties>
 
   <dependencies>
+
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-spring-base</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@
   </properties>
 
   <dependencies>
-
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-spring-base</artifactId>


### PR DESCRIPTION
## Purpose
Fix log4j2 RCE vulnerability

## Approach
log4j2 version set to 2.16.0

## Learning
https://issues.folio.org/browse/MODQM-181
