### PR TITLE
MODQM-226 Improve handling of erroneous MARC holdings Leader positions that cannot be edited via quickMARC

### DIFF
--- a/src/main/java/org/folio/qm/converter/elements/Constants.java
+++ b/src/main/java/org/folio/qm/converter/elements/Constants.java
@@ -107,6 +107,10 @@ public class Constants {
     List.of(CODING_SCHEME, INDICATOR_COUNT, SUBFIELD_CODE_LENGTH,
       ENTRY_MAP_20, ENTRY_MAP_21, ENTRY_MAP_22, ENTRY_MAP_23);
 
+  public static final List<LeaderItem> COMMON_CONSTANT_LEADER_ITEMS =
+    List.of(INDICATOR_COUNT, SUBFIELD_CODE_LENGTH,
+      ENTRY_MAP_20, ENTRY_MAP_21, ENTRY_MAP_22, ENTRY_MAP_23);
+
   private Constants() {
   }
 }

--- a/src/main/java/org/folio/qm/service/impl/DefaultValuesPopulationService.java
+++ b/src/main/java/org/folio/qm/service/impl/DefaultValuesPopulationService.java
@@ -1,0 +1,24 @@
+package org.folio.qm.service.impl;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import org.folio.qm.domain.dto.QuickMarc;
+import org.folio.qm.service.population.MarcPopulationService;
+
+@Service
+public class DefaultValuesPopulationService {
+
+  private final List<MarcPopulationService> marcPopulationServices;
+
+  public DefaultValuesPopulationService(List<MarcPopulationService> marcPopulationServices) {
+    this.marcPopulationServices = marcPopulationServices;
+  }
+
+  public void populate(QuickMarc quickMarc) {
+    marcPopulationServices.stream()
+      .filter(marcPopulationService -> marcPopulationService.supportFormat(quickMarc.getMarcFormat()))
+      .forEach(marcPopulationService -> marcPopulationService.populate(quickMarc));
+  }
+}

--- a/src/main/java/org/folio/qm/service/population/LeaderMarcPopulationService.java
+++ b/src/main/java/org/folio/qm/service/population/LeaderMarcPopulationService.java
@@ -13,21 +13,18 @@ public abstract class LeaderMarcPopulationService implements MarcPopulationServi
 
   @Override
   public void populate(QuickMarc qmRecord) {
-    var leader = populate(qmRecord.getLeader());
+    var initialLeader = qmRecord.getLeader();
+    if (LEADER_LENGTH != initialLeader.length()) {
+      return;
+    }
+
+    var leader = populateValues(initialLeader, new LinkedList<>(COMMON_CONSTANT_LEADER_ITEMS));
 
     qmRecord.setLeader(leader);
   }
 
-  protected abstract String populate(String leader);
-
-  protected String populateValues(String leader, List<LeaderItem> customLeaderItems) {
-    if (LEADER_LENGTH != leader.length()) {
-      return leader;
-    }
-
+  protected String populateValues(String leader, List<LeaderItem> leaderItems) {
     var leaderBuilder = new StringBuilder(leader);
-    var leaderItems = new LinkedList<>(COMMON_CONSTANT_LEADER_ITEMS);
-    leaderItems.addAll(customLeaderItems);
 
     leaderItems.stream()
       .filter(leaderItem -> leaderItem.getPossibleValues().size() == 1)

--- a/src/main/java/org/folio/qm/service/population/LeaderMarcPopulationService.java
+++ b/src/main/java/org/folio/qm/service/population/LeaderMarcPopulationService.java
@@ -1,0 +1,44 @@
+package org.folio.qm.service.population;
+
+import static org.folio.qm.converter.elements.Constants.COMMON_CONSTANT_LEADER_ITEMS;
+import static org.folio.qm.converter.elements.Constants.LEADER_LENGTH;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.folio.qm.converter.elements.LeaderItem;
+import org.folio.qm.domain.dto.QuickMarc;
+
+public abstract class LeaderMarcPopulationService implements MarcPopulationService {
+
+  @Override
+  public void populate(QuickMarc qmRecord) {
+    var leader = populateValues(qmRecord.getLeader());
+
+    qmRecord.setLeader(leader);
+  }
+
+  protected abstract String populateValues(String leader);
+
+  protected String populateValues(String leader, List<LeaderItem> customLeaderItems) {
+    if (LEADER_LENGTH != leader.length()) {
+      return leader;
+    }
+
+    var leaderBuilder = new StringBuilder(leader);
+    var leaderItems = new LinkedList<>(COMMON_CONSTANT_LEADER_ITEMS);
+    leaderItems.addAll(customLeaderItems);
+
+    leaderItems.stream()
+      .filter(leaderItem -> !isValidLeaderValue(leader, leaderItem))
+      .filter(leaderItem -> leaderItem.getPossibleValues().size() == 1)
+      .forEach(leaderItem -> leaderBuilder.setCharAt(leaderItem.getPosition(), leaderItem.getPossibleValues().get(0)));
+
+    return leaderBuilder.toString();
+  }
+
+  private boolean isValidLeaderValue(String leader, LeaderItem item) {
+    return item.getPossibleValues().contains(leader.charAt(item.getPosition()))
+      || item.getPossibleValues().contains(Character.toLowerCase(leader.charAt(item.getPosition())));
+  }
+}

--- a/src/main/java/org/folio/qm/service/population/LeaderMarcPopulationService.java
+++ b/src/main/java/org/folio/qm/service/population/LeaderMarcPopulationService.java
@@ -13,12 +13,12 @@ public abstract class LeaderMarcPopulationService implements MarcPopulationServi
 
   @Override
   public void populate(QuickMarc qmRecord) {
-    var leader = populateValues(qmRecord.getLeader());
+    var leader = populate(qmRecord.getLeader());
 
     qmRecord.setLeader(leader);
   }
 
-  protected abstract String populateValues(String leader);
+  protected abstract String populate(String leader);
 
   protected String populateValues(String leader, List<LeaderItem> customLeaderItems) {
     if (LEADER_LENGTH != leader.length()) {
@@ -30,15 +30,9 @@ public abstract class LeaderMarcPopulationService implements MarcPopulationServi
     leaderItems.addAll(customLeaderItems);
 
     leaderItems.stream()
-      .filter(leaderItem -> !isValidLeaderValue(leader, leaderItem))
       .filter(leaderItem -> leaderItem.getPossibleValues().size() == 1)
       .forEach(leaderItem -> leaderBuilder.setCharAt(leaderItem.getPosition(), leaderItem.getPossibleValues().get(0)));
 
     return leaderBuilder.toString();
-  }
-
-  private boolean isValidLeaderValue(String leader, LeaderItem item) {
-    return item.getPossibleValues().contains(leader.charAt(item.getPosition()))
-      || item.getPossibleValues().contains(Character.toLowerCase(leader.charAt(item.getPosition())));
   }
 }

--- a/src/main/java/org/folio/qm/service/population/MarcPopulationService.java
+++ b/src/main/java/org/folio/qm/service/population/MarcPopulationService.java
@@ -1,0 +1,9 @@
+package org.folio.qm.service.population;
+
+import org.folio.qm.domain.dto.MarcFormat;
+import org.folio.qm.domain.dto.QuickMarc;
+
+public interface MarcPopulationService {
+  void populate(QuickMarc quickMarc);
+  boolean supportFormat(MarcFormat marcFormat);
+}

--- a/src/main/java/org/folio/qm/service/population/impl/HoldingsLeaderMarcPopulationService.java
+++ b/src/main/java/org/folio/qm/service/population/impl/HoldingsLeaderMarcPopulationService.java
@@ -1,7 +1,5 @@
 package org.folio.qm.service.population.impl;
 
-import java.util.Collections;
-
 import org.springframework.stereotype.Service;
 
 import org.folio.qm.domain.dto.MarcFormat;
@@ -13,10 +11,5 @@ public class HoldingsLeaderMarcPopulationService extends LeaderMarcPopulationSer
   @Override
   public boolean supportFormat(MarcFormat marcFormat) {
     return marcFormat.equals(MarcFormat.HOLDINGS);
-  }
-
-  @Override
-  public String populate(String leader) {
-    return populateValues(leader, Collections.emptyList());
   }
 }

--- a/src/main/java/org/folio/qm/service/population/impl/HoldingsLeaderMarcPopulationService.java
+++ b/src/main/java/org/folio/qm/service/population/impl/HoldingsLeaderMarcPopulationService.java
@@ -16,7 +16,7 @@ public class HoldingsLeaderMarcPopulationService extends LeaderMarcPopulationSer
   }
 
   @Override
-  public String populateValues(String leader) {
+  public String populate(String leader) {
     return populateValues(leader, Collections.emptyList());
   }
 }

--- a/src/main/java/org/folio/qm/service/population/impl/HoldingsLeaderMarcPopulationService.java
+++ b/src/main/java/org/folio/qm/service/population/impl/HoldingsLeaderMarcPopulationService.java
@@ -1,0 +1,22 @@
+package org.folio.qm.service.population.impl;
+
+import java.util.Collections;
+
+import org.springframework.stereotype.Service;
+
+import org.folio.qm.domain.dto.MarcFormat;
+import org.folio.qm.service.population.LeaderMarcPopulationService;
+
+@Service
+public class HoldingsLeaderMarcPopulationService extends LeaderMarcPopulationService {
+
+  @Override
+  public boolean supportFormat(MarcFormat marcFormat) {
+    return marcFormat.equals(MarcFormat.HOLDINGS);
+  }
+
+  @Override
+  public String populateValues(String leader) {
+    return populateValues(leader, Collections.emptyList());
+  }
+}

--- a/src/test/java/org/folio/qm/service/population/LeaderMarcPopulationServiceTest.java
+++ b/src/test/java/org/folio/qm/service/population/LeaderMarcPopulationServiceTest.java
@@ -1,10 +1,11 @@
-package org.folio.qm.service.population.impl;
+package org.folio.qm.service.population;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
 import org.folio.qm.domain.dto.QuickMarc;
+import org.folio.qm.service.population.impl.HoldingsLeaderMarcPopulationService;
 import org.folio.qm.support.types.UnitTest;
 
 @UnitTest
@@ -13,6 +14,7 @@ class LeaderMarcPopulationServiceTest {
   private final HoldingsLeaderMarcPopulationService populationService = new HoldingsLeaderMarcPopulationService();
 
   private static final String VALID_LEADER = "00241cx\\\\a2200109zn\\4500";
+  private static final String INVALID_LEADER_LENGTH = "00241cx\\\\a2200109zn\\450";
   private static final String WRONG_INDICATOR_COUNT = "00241cx\\\\a0200109zn\\4500";
   private static final String WRONG_SUBFIELD_CODE_LENGTH = "00241cx\\\\a2000109zn\\4500";
   private static final String WRONG_ENTRY_MAP_20 = "00241cx\\\\a2200109zn\\5500";
@@ -23,6 +25,16 @@ class LeaderMarcPopulationServiceTest {
   @Test
   void shouldReturnInitialLeaderIfValid() {
     var leader = VALID_LEADER;
+    var quickMarc = getQuickMarc(leader);
+
+    populationService.populate(quickMarc);
+
+    assertEquals(leader, quickMarc.getLeader());
+  }
+
+  @Test
+  void shouldReturnInitialLeaderIfWrongLength() {
+    var leader = INVALID_LEADER_LENGTH;
     var quickMarc = getQuickMarc(leader);
 
     populationService.populate(quickMarc);

--- a/src/test/java/org/folio/qm/service/population/LeaderMarcPopulationServiceTest.java
+++ b/src/test/java/org/folio/qm/service/population/LeaderMarcPopulationServiceTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-import org.folio.qm.domain.dto.QuickMarc;
 import org.folio.qm.service.population.impl.HoldingsLeaderMarcPopulationService;
 import org.folio.qm.support.types.UnitTest;
 
@@ -24,68 +23,53 @@ class LeaderMarcPopulationServiceTest {
 
   @Test
   void shouldReturnInitialLeaderIfValid() {
-    var leader = VALID_LEADER;
-    var quickMarc = getQuickMarc(leader);
+    var expectedLeader = VALID_LEADER;
+    var actualLeader = populationService.populate(expectedLeader);
 
-    populationService.populate(quickMarc);
-
-    assertEquals(leader, quickMarc.getLeader());
+    assertEquals(expectedLeader, actualLeader);
   }
 
   @Test
   void shouldReturnInitialLeaderIfWrongLength() {
-    var leader = INVALID_LEADER_LENGTH;
-    var quickMarc = getQuickMarc(leader);
+    var expectedLeader = INVALID_LEADER_LENGTH;
+    var actualLeader = populationService.populate(expectedLeader);
 
-    populationService.populate(quickMarc);
-
-    assertEquals(leader, quickMarc.getLeader());
+    assertEquals(expectedLeader, actualLeader);
   }
 
   @Test
   void shouldSetDefaultValueForInvalidValueOnIndicatorCount() {
-    var quickMarc = getQuickMarc(WRONG_INDICATOR_COUNT);
-    populationService.populate(quickMarc);
-    assertEquals(VALID_LEADER, quickMarc.getLeader());
+    var leader = populationService.populate(WRONG_INDICATOR_COUNT);
+    assertEquals(VALID_LEADER, leader);
   }
 
   @Test
   void shouldSetDefaultValueForInvalidValueOnSubfieldCodeLength() {
-    var quickMarc = getQuickMarc(WRONG_SUBFIELD_CODE_LENGTH);
-    populationService.populate(quickMarc);
-    assertEquals(VALID_LEADER, quickMarc.getLeader());
+    var leader = populationService.populate(WRONG_SUBFIELD_CODE_LENGTH);
+    assertEquals(VALID_LEADER, leader);
   }
 
   @Test
   void shouldSetDefaultValueForInvalidValueOnEntryMap20() {
-    var quickMarc = getQuickMarc(WRONG_ENTRY_MAP_20);
-    populationService.populate(quickMarc);
-    assertEquals(VALID_LEADER, quickMarc.getLeader());
+    var leader = populationService.populate(WRONG_ENTRY_MAP_20);
+    assertEquals(VALID_LEADER, leader);
   }
 
   @Test
   void shouldSetDefaultValueForInvalidValueOnEntryMap21() {
-    var quickMarc = getQuickMarc(WRONG_ENTRY_MAP_21);
-    populationService.populate(quickMarc);
-    assertEquals(VALID_LEADER, quickMarc.getLeader());
+    var leader = populationService.populate(WRONG_ENTRY_MAP_21);
+    assertEquals(VALID_LEADER, leader);
   }
 
   @Test
   void shouldSetDefaultValueForInvalidValueOnEntryMap22() {
-    var quickMarc = getQuickMarc(WRONG_ENTRY_MAP_22);
-    populationService.populate(quickMarc);
-    assertEquals(VALID_LEADER, quickMarc.getLeader());
+    var leader = populationService.populate(WRONG_ENTRY_MAP_22);
+    assertEquals(VALID_LEADER, leader);
   }
 
   @Test
   void shouldSetDefaultValueForInvalidValueOnEntryMap23() {
-    var quickMarc = getQuickMarc(WRONG_ENTRY_MAP_23);
-    populationService.populate(quickMarc);
-    assertEquals(VALID_LEADER, quickMarc.getLeader());
-  }
-
-  private QuickMarc getQuickMarc(String leader) {
-    return new QuickMarc()
-      .leader(leader);
+    var leader = populationService.populate(WRONG_ENTRY_MAP_23);
+    assertEquals(VALID_LEADER, leader);
   }
 }

--- a/src/test/java/org/folio/qm/service/population/impl/HoldingsLeaderMarcPopulationServiceTest.java
+++ b/src/test/java/org/folio/qm/service/population/impl/HoldingsLeaderMarcPopulationServiceTest.java
@@ -1,0 +1,19 @@
+package org.folio.qm.service.population.impl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import org.folio.qm.domain.dto.MarcFormat;
+import org.folio.qm.support.types.UnitTest;
+
+@UnitTest
+class HoldingsLeaderMarcPopulationServiceTest {
+
+  private final HoldingsLeaderMarcPopulationService populationService = new HoldingsLeaderMarcPopulationService();
+
+  @Test
+  void shouldSupportHoldingsFormat() {
+    assertTrue(populationService.supportFormat(MarcFormat.HOLDINGS));
+  }
+}

--- a/src/test/java/org/folio/qm/service/population/impl/HoldingsLeaderMarcPopulationServiceTest.java
+++ b/src/test/java/org/folio/qm/service/population/impl/HoldingsLeaderMarcPopulationServiceTest.java
@@ -1,5 +1,6 @@
 package org.folio.qm.service.population.impl;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -15,5 +16,15 @@ class HoldingsLeaderMarcPopulationServiceTest {
   @Test
   void shouldSupportHoldingsFormat() {
     assertTrue(populationService.supportFormat(MarcFormat.HOLDINGS));
+  }
+
+  @Test
+  void shouldNotSupportBibliographicFormat() {
+    assertFalse(populationService.supportFormat(MarcFormat.BIBLIOGRAPHIC));
+  }
+
+  @Test
+  void shouldNotSupportAuthorityFormat() {
+    assertFalse(populationService.supportFormat(MarcFormat.AUTHORITY));
   }
 }

--- a/src/test/java/org/folio/qm/service/population/impl/LeaderMarcPopulationServiceTest.java
+++ b/src/test/java/org/folio/qm/service/population/impl/LeaderMarcPopulationServiceTest.java
@@ -1,0 +1,79 @@
+package org.folio.qm.service.population.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import org.folio.qm.domain.dto.QuickMarc;
+import org.folio.qm.support.types.UnitTest;
+
+@UnitTest
+class LeaderMarcPopulationServiceTest {
+
+  private final HoldingsLeaderMarcPopulationService populationService = new HoldingsLeaderMarcPopulationService();
+
+  private static final String VALID_LEADER = "00241cx\\\\a2200109zn\\4500";
+  private static final String WRONG_INDICATOR_COUNT = "00241cx\\\\a0200109zn\\4500";
+  private static final String WRONG_SUBFIELD_CODE_LENGTH = "00241cx\\\\a2000109zn\\4500";
+  private static final String WRONG_ENTRY_MAP_20 = "00241cx\\\\a2200109zn\\5500";
+  private static final String WRONG_ENTRY_MAP_21 = "00241cx\\\\a2200109zn\\4400";
+  private static final String WRONG_ENTRY_MAP_22 = "00241cx\\\\a2200109zn\\4510";
+  private static final String WRONG_ENTRY_MAP_23 = "00241cx\\\\a2200109zn\\4501";
+
+  @Test
+  void shouldReturnInitialLeaderIfValid() {
+    var leader = VALID_LEADER;
+    var quickMarc = getQuickMarc(leader);
+
+    populationService.populate(quickMarc);
+
+    assertEquals(leader, quickMarc.getLeader());
+  }
+
+  @Test
+  void shouldSetDefaultValueForInvalidValueOnIndicatorCount() {
+    var quickMarc = getQuickMarc(WRONG_INDICATOR_COUNT);
+    populationService.populate(quickMarc);
+    assertEquals(VALID_LEADER, quickMarc.getLeader());
+  }
+
+  @Test
+  void shouldSetDefaultValueForInvalidValueOnSubfieldCodeLength() {
+    var quickMarc = getQuickMarc(WRONG_SUBFIELD_CODE_LENGTH);
+    populationService.populate(quickMarc);
+    assertEquals(VALID_LEADER, quickMarc.getLeader());
+  }
+
+  @Test
+  void shouldSetDefaultValueForInvalidValueOnEntryMap20() {
+    var quickMarc = getQuickMarc(WRONG_ENTRY_MAP_20);
+    populationService.populate(quickMarc);
+    assertEquals(VALID_LEADER, quickMarc.getLeader());
+  }
+
+  @Test
+  void shouldSetDefaultValueForInvalidValueOnEntryMap21() {
+    var quickMarc = getQuickMarc(WRONG_ENTRY_MAP_21);
+    populationService.populate(quickMarc);
+    assertEquals(VALID_LEADER, quickMarc.getLeader());
+  }
+
+  @Test
+  void shouldSetDefaultValueForInvalidValueOnEntryMap22() {
+    var quickMarc = getQuickMarc(WRONG_ENTRY_MAP_22);
+    populationService.populate(quickMarc);
+    assertEquals(VALID_LEADER, quickMarc.getLeader());
+  }
+
+  @Test
+  void shouldSetDefaultValueForInvalidValueOnEntryMap23() {
+    var quickMarc = getQuickMarc(WRONG_ENTRY_MAP_23);
+    populationService.populate(quickMarc);
+    assertEquals(VALID_LEADER, quickMarc.getLeader());
+  }
+
+  private QuickMarc getQuickMarc(String leader) {
+    return new QuickMarc()
+      .leader(leader);
+  }
+}


### PR DESCRIPTION
### Purpose
Edit MARC holdings record: When a SRS holdings Leader field contains invalid values for the positions that have only one possible value then update the leader positions with the valid values upon user hitting Save

### Approach
- add filling leader positions with default values before validation on create/update

### Learning
[MODQM-226](https://issues.folio.org/browse/MODQM-226)
