### PR TITLE
MODQM-225 Improve handling of erroneous MARC bib Leader positions that cannot be edited via quickMARC

### DIFF
--- a/src/main/java/org/folio/qm/service/population/impl/BibliographicLeaderMarcPopulationService.java
+++ b/src/main/java/org/folio/qm/service/population/impl/BibliographicLeaderMarcPopulationService.java
@@ -1,0 +1,15 @@
+package org.folio.qm.service.population.impl;
+
+import org.springframework.stereotype.Service;
+
+import org.folio.qm.domain.dto.MarcFormat;
+import org.folio.qm.service.population.LeaderMarcPopulationService;
+
+@Service
+public class BibliographicLeaderMarcPopulationService extends LeaderMarcPopulationService {
+
+  @Override
+  public boolean supportFormat(MarcFormat marcFormat) {
+    return marcFormat.equals(MarcFormat.BIBLIOGRAPHIC);
+  }
+}

--- a/src/test/java/org/folio/qm/service/population/impl/BibliographicLeaderMarcPopulationServiceTest.java
+++ b/src/test/java/org/folio/qm/service/population/impl/BibliographicLeaderMarcPopulationServiceTest.java
@@ -1,0 +1,29 @@
+package org.folio.qm.service.population.impl;
+
+import org.folio.qm.domain.dto.MarcFormat;
+import org.folio.qm.support.types.UnitTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@UnitTest
+class BibliographicLeaderMarcPopulationServiceTest {
+
+  private final BibliographicLeaderMarcPopulationService populationService = new BibliographicLeaderMarcPopulationService();
+
+  @Test
+  void shouldSupportBibliographicFormat() {
+    assertTrue(populationService.supportFormat(MarcFormat.BIBLIOGRAPHIC));
+  }
+
+  @Test
+  void shouldNotSupportHoldingsFormat() {
+    assertFalse(populationService.supportFormat(MarcFormat.HOLDINGS));
+  }
+
+  @Test
+  void shouldNotSupportAuthorityFormat() {
+    assertFalse(populationService.supportFormat(MarcFormat.AUTHORITY));
+  }
+}


### PR DESCRIPTION
### Purpose
Edit MARC Bib record: When a SRS bib Leader field contains invalid values for the positions: 00-04, 10-11, 12-16, 20-23 then update the leader positions with the valid values upon user hitting Save

### Learning
[MODQM-225](https://issues.folio.org/browse/MODQM-225)
