### PR TITLE
MODQM-229 Improve handling of erroneous MARC authority Leader positions that cannot be edited via quickMARC

### DIFF
--- a/src/main/java/org/folio/qm/converter/elements/Constants.java
+++ b/src/main/java/org/folio/qm/converter/elements/Constants.java
@@ -42,6 +42,7 @@ import static org.folio.qm.converter.elements.LeaderItem.ENTRY_MAP_22;
 import static org.folio.qm.converter.elements.LeaderItem.ENTRY_MAP_23;
 import static org.folio.qm.converter.elements.LeaderItem.INDICATOR_COUNT;
 import static org.folio.qm.converter.elements.LeaderItem.SUBFIELD_CODE_LENGTH;
+import static org.folio.qm.converter.elements.LeaderItem.AUTHORITY_RECORD_TYPE;
 
 import java.util.List;
 import java.util.Set;
@@ -110,6 +111,10 @@ public class Constants {
 
   public static final List<LeaderItem> COMMON_CONSTANT_LEADER_ITEMS =
     List.of(INDICATOR_COUNT, SUBFIELD_CODE_LENGTH,
+      ENTRY_MAP_20, ENTRY_MAP_21, ENTRY_MAP_22, ENTRY_MAP_23);
+
+  public static final List<LeaderItem> AUTHORITY_CONSTANT_LEADER_ITEMS =
+    List.of(AUTHORITY_RECORD_TYPE, INDICATOR_COUNT, SUBFIELD_CODE_LENGTH,
       ENTRY_MAP_20, ENTRY_MAP_21, ENTRY_MAP_22, ENTRY_MAP_23);
 
   private Constants() {

--- a/src/main/java/org/folio/qm/converter/elements/Constants.java
+++ b/src/main/java/org/folio/qm/converter/elements/Constants.java
@@ -43,6 +43,11 @@ import static org.folio.qm.converter.elements.LeaderItem.ENTRY_MAP_23;
 import static org.folio.qm.converter.elements.LeaderItem.INDICATOR_COUNT;
 import static org.folio.qm.converter.elements.LeaderItem.SUBFIELD_CODE_LENGTH;
 import static org.folio.qm.converter.elements.LeaderItem.AUTHORITY_RECORD_TYPE;
+import static org.folio.qm.converter.elements.LeaderItem.AUTHORITY_CODING_SCHEME;
+import static org.folio.qm.converter.elements.LeaderItem.AUTHORITY_PUNCTUATION_POLICY;
+import static org.folio.qm.converter.elements.LeaderItem.UNDEFINED_CHARACTER_POSITION_7;
+import static org.folio.qm.converter.elements.LeaderItem.UNDEFINED_CHARACTER_POSITION_8;
+import static org.folio.qm.converter.elements.LeaderItem.UNDEFINED_CHARACTER_POSITION_19;
 
 import java.util.List;
 import java.util.Set;
@@ -113,9 +118,11 @@ public class Constants {
     List.of(INDICATOR_COUNT, SUBFIELD_CODE_LENGTH,
       ENTRY_MAP_20, ENTRY_MAP_21, ENTRY_MAP_22, ENTRY_MAP_23);
 
-  public static final List<LeaderItem> AUTHORITY_CONSTANT_LEADER_ITEMS =
-    List.of(AUTHORITY_RECORD_TYPE, INDICATOR_COUNT, SUBFIELD_CODE_LENGTH,
-      ENTRY_MAP_20, ENTRY_MAP_21, ENTRY_MAP_22, ENTRY_MAP_23);
+  public static final List<LeaderItem> AUTHORITY_CONSTANT_LEADER_ITEMS = List.of(
+    UNDEFINED_CHARACTER_POSITION_7, UNDEFINED_CHARACTER_POSITION_8, UNDEFINED_CHARACTER_POSITION_19,
+    AUTHORITY_RECORD_TYPE, AUTHORITY_CODING_SCHEME, AUTHORITY_PUNCTUATION_POLICY,
+    INDICATOR_COUNT, SUBFIELD_CODE_LENGTH,
+    ENTRY_MAP_20, ENTRY_MAP_21, ENTRY_MAP_22, ENTRY_MAP_23);
 
   private Constants() {
   }

--- a/src/main/java/org/folio/qm/converter/elements/LeaderItem.java
+++ b/src/main/java/org/folio/qm/converter/elements/LeaderItem.java
@@ -17,9 +17,9 @@ public enum LeaderItem {
   ENTRY_MAP_23("Entry map", 23, 1, '0'),
 
   //COMMON FIELDS FOR HOLDINGS AND AUTHORITY
-  UNDEFINED_CHARACTER_POSITION_7("Undefined character position", 7, 1, '\\', ' ', '\u00A0'),
-  UNDEFINED_CHARACTER_POSITION_8("Undefined character position", 8, 1, '\\', ' ', '\u00A0'),
-  UNDEFINED_CHARACTER_POSITION_19("Undefined character position", 19, 1, '\\', ' ', '\u00A0'),
+  UNDEFINED_CHARACTER_POSITION_7("Undefined character position", 7, 1, '\\'),
+  UNDEFINED_CHARACTER_POSITION_8("Undefined character position", 8, 1, '\\'),
+  UNDEFINED_CHARACTER_POSITION_19("Undefined character position", 19, 1, '\\'),
 
   //BIB FIELDS
   BIB_RECORD_STATUS("Bib record status", 5, 1, 'a', 'c', 'd', 'n', 'p'),
@@ -43,6 +43,8 @@ public enum LeaderItem {
   AUTHORITY_RECORD_STATUS("Authority record status", 5, 1, 'a', 'c', 'd', 'n', 'o', 's', 'x'),
   AUTHORITY_RECORD_TYPE("Authority type of record", 6, 1, 'z'),
   AUTHORITY_ENCODING_LEVEL("Authority encoding level", 17, 1, 'n', 'o'),
+  AUTHORITY_CODING_SCHEME("Authority character coding scheme", 9, 1, '\\'),
+  AUTHORITY_PUNCTUATION_POLICY("Authority punctuation policy", 18, 1, '\\'),
   PUNCTUATION_POLICY("Punctuation policy", 18, 1, '\\', ' ', '\u00A0', 'c', 'i', 'u');
 
   private final String name;

--- a/src/main/java/org/folio/qm/service/population/LeaderMarcPopulationService.java
+++ b/src/main/java/org/folio/qm/service/population/LeaderMarcPopulationService.java
@@ -2,7 +2,6 @@ package org.folio.qm.service.population;
 
 import static org.folio.qm.converter.elements.Constants.LEADER_LENGTH;
 
-import java.util.LinkedList;
 import java.util.List;
 
 import org.folio.qm.converter.elements.LeaderItem;
@@ -17,7 +16,7 @@ public abstract class LeaderMarcPopulationService implements MarcPopulationServi
       return;
     }
 
-    var leader = populateValues(initialLeader, new LinkedList<>(getConstantLeaderItems()));
+    var leader = populateValues(initialLeader, getConstantLeaderItems());
 
     qmRecord.setLeader(leader);
   }

--- a/src/main/java/org/folio/qm/service/population/LeaderMarcPopulationService.java
+++ b/src/main/java/org/folio/qm/service/population/LeaderMarcPopulationService.java
@@ -1,6 +1,5 @@
 package org.folio.qm.service.population;
 
-import static org.folio.qm.converter.elements.Constants.COMMON_CONSTANT_LEADER_ITEMS;
 import static org.folio.qm.converter.elements.Constants.LEADER_LENGTH;
 
 import java.util.LinkedList;
@@ -18,10 +17,12 @@ public abstract class LeaderMarcPopulationService implements MarcPopulationServi
       return;
     }
 
-    var leader = populateValues(initialLeader, new LinkedList<>(COMMON_CONSTANT_LEADER_ITEMS));
+    var leader = populateValues(initialLeader, new LinkedList<>(getConstantLeaderItems()));
 
     qmRecord.setLeader(leader);
   }
+
+  protected abstract List<LeaderItem> getConstantLeaderItems();
 
   protected String populateValues(String leader, List<LeaderItem> leaderItems) {
     var leaderBuilder = new StringBuilder(leader);

--- a/src/main/java/org/folio/qm/service/population/impl/AuthorityLeaderMarcPopulationService.java
+++ b/src/main/java/org/folio/qm/service/population/impl/AuthorityLeaderMarcPopulationService.java
@@ -1,0 +1,14 @@
+package org.folio.qm.service.population.impl;
+
+import org.folio.qm.domain.dto.MarcFormat;
+import org.folio.qm.service.population.LeaderMarcPopulationService;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthorityLeaderMarcPopulationService extends LeaderMarcPopulationService {
+
+  @Override
+  public boolean supportFormat(MarcFormat marcFormat) {
+    return marcFormat.equals(MarcFormat.AUTHORITY);
+  }
+}

--- a/src/main/java/org/folio/qm/service/population/impl/AuthorityLeaderMarcPopulationService.java
+++ b/src/main/java/org/folio/qm/service/population/impl/AuthorityLeaderMarcPopulationService.java
@@ -1,13 +1,14 @@
 package org.folio.qm.service.population.impl;
 
-import org.springframework.stereotype.Service;
-
-import org.folio.qm.converter.elements.LeaderItem;
-import org.folio.qm.domain.dto.MarcFormat;
-import org.folio.qm.service.population.LeaderMarcPopulationService;
 import static org.folio.qm.converter.elements.Constants.AUTHORITY_CONSTANT_LEADER_ITEMS;
 
 import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import org.folio.qm.domain.dto.MarcFormat;
+import org.folio.qm.service.population.LeaderMarcPopulationService;
+import org.folio.qm.converter.elements.LeaderItem;
 
 @Service
 public class AuthorityLeaderMarcPopulationService extends LeaderMarcPopulationService {

--- a/src/main/java/org/folio/qm/service/population/impl/AuthorityLeaderMarcPopulationService.java
+++ b/src/main/java/org/folio/qm/service/population/impl/AuthorityLeaderMarcPopulationService.java
@@ -1,8 +1,13 @@
 package org.folio.qm.service.population.impl;
 
+import org.springframework.stereotype.Service;
+
+import org.folio.qm.converter.elements.LeaderItem;
 import org.folio.qm.domain.dto.MarcFormat;
 import org.folio.qm.service.population.LeaderMarcPopulationService;
-import org.springframework.stereotype.Service;
+import static org.folio.qm.converter.elements.Constants.AUTHORITY_CONSTANT_LEADER_ITEMS;
+
+import java.util.List;
 
 @Service
 public class AuthorityLeaderMarcPopulationService extends LeaderMarcPopulationService {
@@ -10,5 +15,10 @@ public class AuthorityLeaderMarcPopulationService extends LeaderMarcPopulationSe
   @Override
   public boolean supportFormat(MarcFormat marcFormat) {
     return marcFormat.equals(MarcFormat.AUTHORITY);
+  }
+
+  @Override
+  protected List<LeaderItem> getConstantLeaderItems() {
+    return AUTHORITY_CONSTANT_LEADER_ITEMS;
   }
 }

--- a/src/main/java/org/folio/qm/service/population/impl/BibliographicLeaderMarcPopulationService.java
+++ b/src/main/java/org/folio/qm/service/population/impl/BibliographicLeaderMarcPopulationService.java
@@ -1,13 +1,14 @@
 package org.folio.qm.service.population.impl;
 
-import org.springframework.stereotype.Service;
-
-import org.folio.qm.converter.elements.LeaderItem;
-import org.folio.qm.domain.dto.MarcFormat;
-import org.folio.qm.service.population.LeaderMarcPopulationService;
 import static org.folio.qm.converter.elements.Constants.COMMON_CONSTANT_LEADER_ITEMS;
 
 import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import org.folio.qm.domain.dto.MarcFormat;
+import org.folio.qm.service.population.LeaderMarcPopulationService;
+import org.folio.qm.converter.elements.LeaderItem;
 
 @Service
 public class BibliographicLeaderMarcPopulationService extends LeaderMarcPopulationService {

--- a/src/main/java/org/folio/qm/service/population/impl/BibliographicLeaderMarcPopulationService.java
+++ b/src/main/java/org/folio/qm/service/population/impl/BibliographicLeaderMarcPopulationService.java
@@ -2,8 +2,12 @@ package org.folio.qm.service.population.impl;
 
 import org.springframework.stereotype.Service;
 
+import org.folio.qm.converter.elements.LeaderItem;
 import org.folio.qm.domain.dto.MarcFormat;
 import org.folio.qm.service.population.LeaderMarcPopulationService;
+import static org.folio.qm.converter.elements.Constants.COMMON_CONSTANT_LEADER_ITEMS;
+
+import java.util.List;
 
 @Service
 public class BibliographicLeaderMarcPopulationService extends LeaderMarcPopulationService {
@@ -11,5 +15,10 @@ public class BibliographicLeaderMarcPopulationService extends LeaderMarcPopulati
   @Override
   public boolean supportFormat(MarcFormat marcFormat) {
     return marcFormat.equals(MarcFormat.BIBLIOGRAPHIC);
+  }
+
+  @Override
+  protected List<LeaderItem> getConstantLeaderItems() {
+    return COMMON_CONSTANT_LEADER_ITEMS;
   }
 }

--- a/src/main/java/org/folio/qm/service/population/impl/HoldingsLeaderMarcPopulationService.java
+++ b/src/main/java/org/folio/qm/service/population/impl/HoldingsLeaderMarcPopulationService.java
@@ -1,13 +1,14 @@
 package org.folio.qm.service.population.impl;
 
-import org.springframework.stereotype.Service;
-
-import org.folio.qm.converter.elements.LeaderItem;
-import org.folio.qm.domain.dto.MarcFormat;
-import org.folio.qm.service.population.LeaderMarcPopulationService;
 import static org.folio.qm.converter.elements.Constants.COMMON_CONSTANT_LEADER_ITEMS;
 
 import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import org.folio.qm.domain.dto.MarcFormat;
+import org.folio.qm.service.population.LeaderMarcPopulationService;
+import org.folio.qm.converter.elements.LeaderItem;
 
 @Service
 public class HoldingsLeaderMarcPopulationService extends LeaderMarcPopulationService {

--- a/src/main/java/org/folio/qm/service/population/impl/HoldingsLeaderMarcPopulationService.java
+++ b/src/main/java/org/folio/qm/service/population/impl/HoldingsLeaderMarcPopulationService.java
@@ -2,8 +2,12 @@ package org.folio.qm.service.population.impl;
 
 import org.springframework.stereotype.Service;
 
+import org.folio.qm.converter.elements.LeaderItem;
 import org.folio.qm.domain.dto.MarcFormat;
 import org.folio.qm.service.population.LeaderMarcPopulationService;
+import static org.folio.qm.converter.elements.Constants.COMMON_CONSTANT_LEADER_ITEMS;
+
+import java.util.List;
 
 @Service
 public class HoldingsLeaderMarcPopulationService extends LeaderMarcPopulationService {
@@ -11,5 +15,10 @@ public class HoldingsLeaderMarcPopulationService extends LeaderMarcPopulationSer
   @Override
   public boolean supportFormat(MarcFormat marcFormat) {
     return marcFormat.equals(MarcFormat.HOLDINGS);
+  }
+
+  @Override
+  protected List<LeaderItem> getConstantLeaderItems() {
+    return COMMON_CONSTANT_LEADER_ITEMS;
   }
 }

--- a/src/test/java/org/folio/qm/service/population/LeaderMarcPopulationServiceTest.java
+++ b/src/test/java/org/folio/qm/service/population/LeaderMarcPopulationServiceTest.java
@@ -2,11 +2,12 @@ package org.folio.qm.service.population;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import static org.folio.qm.converter.elements.Constants.COMMON_CONSTANT_LEADER_ITEMS;
+
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import static org.folio.qm.converter.elements.Constants.COMMON_CONSTANT_LEADER_ITEMS;
 import org.folio.qm.converter.elements.LeaderItem;
 import org.folio.qm.domain.dto.MarcFormat;
 import org.folio.qm.domain.dto.QuickMarc;

--- a/src/test/java/org/folio/qm/service/population/LeaderMarcPopulationServiceTest.java
+++ b/src/test/java/org/folio/qm/service/population/LeaderMarcPopulationServiceTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import static org.folio.qm.converter.elements.Constants.COMMON_CONSTANT_LEADER_ITEMS;
 import org.folio.qm.converter.elements.LeaderItem;
 import org.folio.qm.domain.dto.MarcFormat;
 import org.folio.qm.domain.dto.QuickMarc;
@@ -15,6 +16,11 @@ import org.folio.qm.support.types.UnitTest;
 class LeaderMarcPopulationServiceTest {
 
   private final LeaderMarcPopulationService populationService = new LeaderMarcPopulationService() {
+    @Override
+    protected List<LeaderItem> getConstantLeaderItems() {
+      return COMMON_CONSTANT_LEADER_ITEMS;
+    }
+
     @Override
     public boolean supportFormat(MarcFormat marcFormat) {
       return true;
@@ -109,6 +115,11 @@ class LeaderMarcPopulationServiceTest {
       @Override
       public boolean supportFormat(MarcFormat marcFormat) {
         return true;
+      }
+
+      @Override
+      protected List<LeaderItem> getConstantLeaderItems() {
+        return COMMON_CONSTANT_LEADER_ITEMS;
       }
 
       @Override

--- a/src/test/java/org/folio/qm/service/population/LeaderMarcPopulationServiceTest.java
+++ b/src/test/java/org/folio/qm/service/population/LeaderMarcPopulationServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static org.folio.qm.converter.elements.Constants.COMMON_CONSTANT_LEADER_ITEMS;
 
+import java.util.LinkedList;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -120,7 +121,7 @@ class LeaderMarcPopulationServiceTest {
 
       @Override
       protected List<LeaderItem> getConstantLeaderItems() {
-        return COMMON_CONSTANT_LEADER_ITEMS;
+        return new LinkedList<>(COMMON_CONSTANT_LEADER_ITEMS);
       }
 
       @Override

--- a/src/test/java/org/folio/qm/service/population/impl/AuthorityLeaderMarcPopulationServiceTest.java
+++ b/src/test/java/org/folio/qm/service/population/impl/AuthorityLeaderMarcPopulationServiceTest.java
@@ -1,0 +1,29 @@
+package org.folio.qm.service.population.impl;
+
+import org.folio.qm.domain.dto.MarcFormat;
+import org.folio.qm.support.types.UnitTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@UnitTest
+class AuthorityLeaderMarcPopulationServiceTest {
+
+  private final AuthorityLeaderMarcPopulationService populationService = new AuthorityLeaderMarcPopulationService();
+
+  @Test
+  void shouldSupportAuthorityFormat() {
+    assertTrue(populationService.supportFormat(MarcFormat.AUTHORITY));
+  }
+
+  @Test
+  void shouldNotSupportBibliographicFormat() {
+    assertFalse(populationService.supportFormat(MarcFormat.BIBLIOGRAPHIC));
+  }
+
+  @Test
+  void shouldNotSupportHoldingsFormat() {
+    assertFalse(populationService.supportFormat(MarcFormat.HOLDINGS));
+  }
+}

--- a/src/test/java/org/folio/qm/service/population/impl/AuthorityLeaderMarcPopulationServiceTest.java
+++ b/src/test/java/org/folio/qm/service/population/impl/AuthorityLeaderMarcPopulationServiceTest.java
@@ -1,6 +1,7 @@
 package org.folio.qm.service.population.impl;
 
 import org.folio.qm.domain.dto.MarcFormat;
+import org.folio.qm.domain.dto.QuickMarc;
 import org.folio.qm.support.types.UnitTest;
 import org.junit.jupiter.api.Test;
 
@@ -11,6 +12,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class AuthorityLeaderMarcPopulationServiceTest {
 
   private final AuthorityLeaderMarcPopulationService populationService = new AuthorityLeaderMarcPopulationService();
+
+  private static final String VALID_LEADER = "06059cz\\\\a2201201n\\\\4500";
+  private static final String WRONG_AUTHORITY_RECORD_TYPE = "06059ca\\\\a2201201n\\\\4500";
 
   @Test
   void shouldSupportAuthorityFormat() {
@@ -25,5 +29,17 @@ class AuthorityLeaderMarcPopulationServiceTest {
   @Test
   void shouldNotSupportHoldingsFormat() {
     assertFalse(populationService.supportFormat(MarcFormat.HOLDINGS));
+  }
+
+  @Test
+  void shouldSetDefaultValueForInvalidValueOnAuthorityRecordType() {
+    var quickMarc = getQuickMarc(WRONG_AUTHORITY_RECORD_TYPE);
+    populationService.populate(quickMarc);
+    assertEquals(VALID_LEADER, quickMarc.getLeader());
+  }
+
+  private QuickMarc getQuickMarc(String leader) {
+    return new QuickMarc()
+      .leader(leader);
   }
 }

--- a/src/test/java/org/folio/qm/service/population/impl/AuthorityLeaderMarcPopulationServiceTest.java
+++ b/src/test/java/org/folio/qm/service/population/impl/AuthorityLeaderMarcPopulationServiceTest.java
@@ -5,6 +5,7 @@ import org.folio.qm.domain.dto.QuickMarc;
 import org.folio.qm.support.types.UnitTest;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/src/test/java/org/folio/qm/service/population/impl/AuthorityLeaderMarcPopulationServiceTest.java
+++ b/src/test/java/org/folio/qm/service/population/impl/AuthorityLeaderMarcPopulationServiceTest.java
@@ -14,8 +14,13 @@ class AuthorityLeaderMarcPopulationServiceTest {
 
   private final AuthorityLeaderMarcPopulationService populationService = new AuthorityLeaderMarcPopulationService();
 
-  private static final String VALID_LEADER = "06059cz\\\\a2201201n\\\\4500";
-  private static final String WRONG_AUTHORITY_RECORD_TYPE = "06059ca\\\\a2201201n\\\\4500";
+  private static final String VALID_LEADER = "06059cz\\\\\\2201201n\\\\4500";
+  private static final String WRONG_AUTHORITY_RECORD_TYPE = "06059ca\\\\\\2201201n\\\\4500";
+  private static final String WRONG_AUTHORITY_CODING_SCHEME = "06059cz\\\\02201201n\\\\4500";
+  private static final String WRONG_AUTHORITY_PUNCTUATION_POLICY = "06059cz\\\\\\2201201na\\4500";
+  private static final String WRONG_UNDEFINED_CHARACTER_POSITION_7 = "06059cza\\\\2201201n\\\\4500";
+  private static final String WRONG_UNDEFINED_CHARACTER_POSITION_8 = "06059cz\\a\\2201201n\\\\4500";
+  private static final String WRONG_UNDEFINED_CHARACTER_POSITION_19 = "06059cz\\\\\\2201201n\\a4500";
 
   @Test
   void shouldSupportAuthorityFormat() {
@@ -35,6 +40,41 @@ class AuthorityLeaderMarcPopulationServiceTest {
   @Test
   void shouldSetDefaultValueForInvalidValueOnAuthorityRecordType() {
     var quickMarc = getQuickMarc(WRONG_AUTHORITY_RECORD_TYPE);
+    populationService.populate(quickMarc);
+    assertEquals(VALID_LEADER, quickMarc.getLeader());
+  }
+
+  @Test
+  void shouldSetDefaultValueForInvalidValueOnAuthorityCodingScheme() {
+    var quickMarc = getQuickMarc(WRONG_AUTHORITY_CODING_SCHEME);
+    populationService.populate(quickMarc);
+    assertEquals(VALID_LEADER, quickMarc.getLeader());
+  }
+
+  @Test
+  void shouldSetDefaultValueForInvalidValueOnAuthorityPunctuationPolicy() {
+    var quickMarc = getQuickMarc(WRONG_AUTHORITY_PUNCTUATION_POLICY);
+    populationService.populate(quickMarc);
+    assertEquals(VALID_LEADER, quickMarc.getLeader());
+  }
+
+  @Test
+  void shouldSetDefaultValueForInvalidValueOnAuthorityUndefinedCharacterPosition7() {
+    var quickMarc = getQuickMarc(WRONG_UNDEFINED_CHARACTER_POSITION_7);
+    populationService.populate(quickMarc);
+    assertEquals(VALID_LEADER, quickMarc.getLeader());
+  }
+
+  @Test
+  void shouldSetDefaultValueForInvalidValueOnAuthorityUndefinedCharacterPosition8() {
+    var quickMarc = getQuickMarc(WRONG_UNDEFINED_CHARACTER_POSITION_8);
+    populationService.populate(quickMarc);
+    assertEquals(VALID_LEADER, quickMarc.getLeader());
+  }
+
+  @Test
+  void shouldSetDefaultValueForInvalidValueOnAuthorityUndefinedCharacterPosition19() {
+    var quickMarc = getQuickMarc(WRONG_UNDEFINED_CHARACTER_POSITION_19);
     populationService.populate(quickMarc);
     assertEquals(VALID_LEADER, quickMarc.getLeader());
   }

--- a/src/test/java/org/folio/qm/service/population/impl/AuthorityLeaderMarcPopulationServiceTest.java
+++ b/src/test/java/org/folio/qm/service/population/impl/AuthorityLeaderMarcPopulationServiceTest.java
@@ -1,13 +1,14 @@
 package org.folio.qm.service.population.impl;
 
-import org.folio.qm.domain.dto.MarcFormat;
-import org.folio.qm.domain.dto.QuickMarc;
-import org.folio.qm.support.types.UnitTest;
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import org.folio.qm.domain.dto.MarcFormat;
+import org.folio.qm.domain.dto.QuickMarc;
+import org.folio.qm.support.types.UnitTest;
 
 @UnitTest
 class AuthorityLeaderMarcPopulationServiceTest {

--- a/src/test/java/org/folio/qm/service/population/impl/BibliographicLeaderMarcPopulationServiceTest.java
+++ b/src/test/java/org/folio/qm/service/population/impl/BibliographicLeaderMarcPopulationServiceTest.java
@@ -1,11 +1,12 @@
 package org.folio.qm.service.population.impl;
 
-import org.folio.qm.domain.dto.MarcFormat;
-import org.folio.qm.support.types.UnitTest;
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import org.folio.qm.domain.dto.MarcFormat;
+import org.folio.qm.support.types.UnitTest;
 
 @UnitTest
 class BibliographicLeaderMarcPopulationServiceTest {


### PR DESCRIPTION
### Approach
Edit MARC authority record: When a SRS authority Leader field contains invalid values for the positions listed in the below table then update the leader positions with the valid values upon user hitting Save

### Learning
[MODQM-229](https://issues.folio.org/browse/MODQM-229)
