### PR TITLE
MODQM-253 Changes to Leader position 17 validation AND 008 byte

### DIFF
--- a/src/main/java/org/folio/qm/converter/elements/Constants.java
+++ b/src/main/java/org/folio/qm/converter/elements/Constants.java
@@ -65,7 +65,6 @@ public class Constants {
   public static final int TYPE_OF_RECORD_LEADER_POS = 6;
   public static final int BLVL_LEADER_POS = 7;
   public static final int DESC_LEADER_POS = 18;
-  public static final int ELVL_LEADER_POS = 17;
   public static final int LCCN_NEW_PREFIX_LENGTH = 2;
   public static final int LCCN_OLD_PREFIX_LENGTH = 3;
   public static final int SPECIFIC_ELEMENTS_BEGIN_INDEX = 18;
@@ -86,7 +85,6 @@ public class Constants {
   public static final String CATEGORY_NAME = "$categoryName";
   public static final String BLVL = "BLvl";
   public static final String DESC = "Desc";
-  public static final String ELVL = "ELvl";
   public static final String TYPE = "Type";
 
   public static final Set<String> COMPLEX_CONTROL_FIELD_TAGS = Set.of(

--- a/src/main/java/org/folio/qm/converter/field/dto/Tag008BibliographicControlFieldConverter.java
+++ b/src/main/java/org/folio/qm/converter/field/dto/Tag008BibliographicControlFieldConverter.java
@@ -3,7 +3,6 @@ package org.folio.qm.converter.field.dto;
 import static org.folio.qm.converter.elements.Constants.BLANK_REPLACEMENT;
 import static org.folio.qm.converter.elements.Constants.BLVL;
 import static org.folio.qm.converter.elements.Constants.DESC;
-import static org.folio.qm.converter.elements.Constants.ELVL;
 import static org.folio.qm.converter.elements.Constants.SPACE_CHARACTER;
 import static org.folio.qm.converter.elements.Constants.SPECIFIC_ELEMENTS_BEGIN_INDEX;
 import static org.folio.qm.converter.elements.Constants.SPECIFIC_ELEMENTS_END_INDEX;
@@ -38,7 +37,6 @@ public class Tag008BibliographicControlFieldConverter implements VariableFieldCo
     var contentMap = new LinkedHashMap<>();
     contentMap.put(TYPE, Character.toString(typeOfRecord));
     contentMap.put(BLVL, change(implDefined1[0]));
-    contentMap.put(ELVL, change(implDefined2[0]));
     contentMap.put(DESC, change(implDefined2[1]));
     contentMap.putAll(fillContentMap(Tag008Configuration.getCommonItems(), content, -1));
     contentMap.putAll(fillContentMap(configuration.getSpecificItems(),

--- a/src/main/java/org/folio/qm/validation/impl/common/LeaderMatch008RecordValidationRule.java
+++ b/src/main/java/org/folio/qm/validation/impl/common/LeaderMatch008RecordValidationRule.java
@@ -4,8 +4,6 @@ import static java.util.Objects.nonNull;
 
 import static org.folio.qm.converter.elements.Constants.DESC;
 import static org.folio.qm.converter.elements.Constants.DESC_LEADER_POS;
-import static org.folio.qm.converter.elements.Constants.ELVL;
-import static org.folio.qm.converter.elements.Constants.ELVL_LEADER_POS;
 import static org.folio.qm.converter.elements.Constants.TAG_008_CONTROL_FIELD;
 
 import java.util.List;
@@ -42,9 +40,7 @@ public class LeaderMatch008RecordValidationRule extends RecordValidationRule {
     @SuppressWarnings("unchecked")
     var contentMap = ((Map<String, Object>) content);
     return nonNull(contentMap)
-      && nonNull(contentMap.get(ELVL))
       && nonNull(contentMap.get(DESC))
-      && contentMap.get(ELVL).toString().equals(Character.toString(leader.charAt(ELVL_LEADER_POS)))
       && contentMap.get(DESC).toString().equals(Character.toString(leader.charAt(DESC_LEADER_POS)));
   }
 

--- a/src/test/java/org/folio/qm/support/utils/testdata/Tag008FieldTestData.java
+++ b/src/test/java/org/folio/qm/support/utils/testdata/Tag008FieldTestData.java
@@ -80,7 +80,6 @@ public enum Tag008FieldTestData {
     Map<String, Object> content = new LinkedHashMap<>();
     content.put("Type", "a");
     content.put("BLvl", "a");
-    content.put("ELvl", "\\");
     content.put("Desc", "\\");
     content.put("Entered", "abcdef");
     content.put("DtSt", "g");
@@ -107,7 +106,6 @@ public enum Tag008FieldTestData {
     Map<String, Object> content = new LinkedHashMap<>();
     content.put("Type", "a");
     content.put("BLvl", "a");
-    content.put("ELvl", "\\");
     content.put("Desc", "\\");
     content.put("Entered", "abcdef");
     content.put("DtSt", "g");
@@ -134,7 +132,6 @@ public enum Tag008FieldTestData {
     Map<String, Object> content = new LinkedHashMap<>();
     content.put("Type", "s");
     content.put("BLvl", "b");
-    content.put("ELvl", "\\");
     content.put("Desc", "\\");
     content.put("Entered", "abcdef");
     content.put("DtSt", "g");
@@ -162,7 +159,6 @@ public enum Tag008FieldTestData {
     Map<String, Object> content = new LinkedHashMap<>();
     content.put("Type", "m");
     content.put("BLvl", "a");
-    content.put("ELvl", "\\");
     content.put("Desc", "\\");
     content.put("Entered", "abcdef");
     content.put("DtSt", "g");
@@ -183,7 +179,6 @@ public enum Tag008FieldTestData {
     Map<String, Object> content = new LinkedHashMap<>();
     content.put("Type", "e");
     content.put("BLvl", "a");
-    content.put("ELvl", "\\");
     content.put("Desc", "\\");
     content.put("Entered", "abcdef");
     content.put("DtSt", "g");
@@ -207,7 +202,6 @@ public enum Tag008FieldTestData {
     Map<String, Object> content = new LinkedHashMap<>();
     content.put("Type", "p");
     content.put("BLvl", "a");
-    content.put("ELvl", "\\");
     content.put("Desc", "\\");
     content.put("Entered", "abcdef");
     content.put("DtSt", "g");
@@ -225,7 +219,6 @@ public enum Tag008FieldTestData {
     Map<String, Object> content = new LinkedHashMap<>();
     content.put("Type", "c");
     content.put("BLvl", "a");
-    content.put("ELvl", "\\");
     content.put("Desc", "\\");
     content.put("Entered", "abcdef");
     content.put("DtSt", "g");
@@ -250,7 +243,6 @@ public enum Tag008FieldTestData {
     Map<String, Object> content = new LinkedHashMap<>();
     content.put("Type", "i");
     content.put("BLvl", "a");
-    content.put("ELvl", "\\");
     content.put("Desc", "\\");
     content.put("Entered", "abcdef");
     content.put("DtSt", "g");
@@ -275,7 +267,6 @@ public enum Tag008FieldTestData {
     Map<String, Object> content = new LinkedHashMap<>();
     content.put("Type", "h");
     content.put("BLvl", "a");
-    content.put("ELvl", "\\");
     content.put("Desc", "\\");
     content.put("Entered", "abcdef");
     content.put("DtSt", "g");
@@ -293,7 +284,6 @@ public enum Tag008FieldTestData {
     Map<String, Object> content = new LinkedHashMap<>();
     content.put("Type", "g");
     content.put("BLvl", "a");
-    content.put("ELvl", "\\");
     content.put("Desc", "\\");
     content.put("Entered", "abcdef");
     content.put("DtSt", "g");


### PR DESCRIPTION
## Purpose
On MARC field 008 > remove the ELvl byte if it is only present because it is Leader 17 position field
Make sure that Leader position 17 accepts the values noted for Leader position 17 as outlined https://issues.folio.org/browse/MODQM-164

JIRA: https://issues.folio.org/browse/MODQM-253

## Approach
- Remove validation of Elvl in 008 tag
- Remove Elvl from DTO converter

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
