### PR TITLE
MODQM-267 Back-end: Cannot access a MARC bib record because creator has been deleted

### DIFF
--- a/src/main/java/org/folio/qm/client/UsersClient.java
+++ b/src/main/java/org/folio/qm/client/UsersClient.java
@@ -8,7 +8,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@FeignClient(value = "users")
+@FeignClient(value = "users", decode404 = true)
 public interface UsersClient {
 
   @GetMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/org/folio/qm/controller/RecordsEditorIT.java
+++ b/src/test/java/org/folio/qm/controller/RecordsEditorIT.java
@@ -134,6 +134,29 @@ class RecordsEditorIT extends BaseIT {
   }
 
   @Test
+  void testGetQuickMarcHoldingsRecord_updatedByUserNotFound() throws Exception {
+    log.info("===== Verify GET Holdings record: user is not found =====");
+
+    mockGet(changeManagerPath(EXTERNAL_ID, EXISTED_EXTERNAL_ID), readFile(PARSED_RECORD_HOLDINGS_DTO_PATH), SC_OK,
+      wireMockServer);
+    mockGet(usersByIdPath(JOHN_USER_ID), null, SC_NOT_FOUND, wireMockServer);
+    mockGet(FIELD_PROTECTION_SETTINGS_PATH, readFile(TestEntitiesUtils.FIELD_PROTECTION_SETTINGS_PATH), SC_OK,
+      wireMockServer);
+
+    getResultActions(recordsEditorPath(EXTERNAL_ID, EXISTED_EXTERNAL_ID))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.marcFormat").value(MarcFormat.HOLDINGS.getValue()))
+      .andExpect(jsonPath("$.parsedRecordDtoId").value(VALID_PARSED_RECORD_DTO_ID.toString()))
+      .andExpect(jsonPath("$.externalId").value(EXISTED_EXTERNAL_ID.toString()))
+      .andExpect(jsonPath("$.externalHrid").value(EXISTED_EXTERNAL_HRID))
+      .andExpect(jsonPath("$.suppressDiscovery").value(Boolean.FALSE))
+      .andExpect(jsonPath("$.parsedRecordId").value(VALID_PARSED_RECORD_ID.toString()))
+      .andExpect(jsonPath("$.updateInfo.updatedBy.userId").doesNotExist());
+
+    checkParseRecordDtoId();
+  }
+
+  @Test
   void testGetQuickMarcAuthorityRecord() throws Exception {
     log.info("===== Verify GET Authority record: Successful =====");
 


### PR DESCRIPTION
## Purpose
Fix error with retrieving record when updatedBy user is not found.

JIRA: https://issues.folio.org/browse/MODQM-267

## Approach
- Update UsersClient to decode 404
- Add test

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
