### PR TITLE
Tmp prepare dev v2.6

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 ## 2.5.0 - Released
 
 ### Changes
+* [MODQM-253](https://issues.folio.org/browse/MODQM-253) - Changes to Leader position 17 validation AND 008 byte
 * [MODQM-260](https://issues.folio.org/browse/MODQM-260) - Supports users interface 15.0 16.0
 * [MODQM-291](https://issues.folio.org/browse/MODQM-291) - Upgrade to folio-spring-base v5.0.0
 * [MODQM-281](https://issues.folio.org/browse/MODQM-281) - Remove 008 Desc from request/response on edit/derive MARC bib

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,13 @@
-## 2.5.0 IN-PROGRESS
+## 2.6.0 IN-PROGRESS
 
-* [MODQM-260] (https://issues.folio.org/browse/MODQM-260) - Supports users interface 15.0 16.0
 * [MODQM-271] (https://issues.folio.org/browse/MODQM-271) - Extend GET /records endpoint to support bib-auth links
-* [MODQM-291] (https://issues.folio.org/browse/MODQM-291) - Upgrade to folio-spring-base v5.0.0
-* [MODQM-281] (https://issues.folio.org/browse/MODQM-281) - Remove 008 Desc from request/response on edit/derive MARC bib
+
+## 2.5.0 - Released
+
+### Changes
+* [MODQM-260](https://issues.folio.org/browse/MODQM-260) - Supports users interface 15.0 16.0
+* [MODQM-291](https://issues.folio.org/browse/MODQM-291) - Upgrade to folio-spring-base v5.0.0
+* [MODQM-281](https://issues.folio.org/browse/MODQM-281) - Remove 008 Desc from request/response on edit/derive MARC bib
 
 ## 2.4.0 - Released
 

--- a/doc/RELEASES.md
+++ b/doc/RELEASES.md
@@ -9,3 +9,4 @@
 | R3 2021          | Kiwi            | v2.2               |
 | R1 2022          | Lotus           | v2.3               |
 | R2 2022          | Morning Glory   | v2.4               |
+| R3 2022          | Nolana          | v2.5               |

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>mod-quick-marc</artifactId>
-  <version>2.5.0-SNAPSHOT</version>
+  <version>2.6.0-SNAPSHOT</version>
   <description>API for quickMARC - in-app editor for MARC records in SRS</description>
   <packaging>jar</packaging>
 


### PR DESCRIPTION
## Purpose
Prepare for next development iteration

### Learning
[MODQM-290](https://issues.folio.org/browse/MODQM-290)
Release branch `release/v2.5` was created separately from branch `tmp-release-v2.5` with excluded bib-authority linking feature