### PR TITLE
MODQM-296 - $9 with value in "invalid UUID format" leads to "500" error in SRS

### DIFF
--- a/src/main/java/org/folio/qm/converter/field/dto/AuthorityDataFieldConverter.java
+++ b/src/main/java/org/folio/qm/converter/field/dto/AuthorityDataFieldConverter.java
@@ -1,0 +1,38 @@
+package org.folio.qm.converter.field.dto;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.folio.qm.domain.dto.FieldItem;
+import org.folio.qm.domain.dto.MarcFormat;
+import org.folio.qm.util.MarcUtils;
+import org.marc4j.marc.DataField;
+import org.marc4j.marc.Leader;
+import org.marc4j.marc.Subfield;
+import org.marc4j.marc.VariableField;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthorityDataFieldConverter extends CommonDataFieldConverter {
+  private static final char AUTHORITY_ID_SUBFIELD_CODE = '9';
+
+  @Override
+  public FieldItem convert(DataField field, Leader leader) {
+    var fieldItem = super.convert(field, leader);
+    extractAuthorityId(field.getSubfields()).ifPresent(fieldItem::setAuthorityId);
+    return fieldItem;
+  }
+
+  @Override
+  public boolean canProcess(VariableField field, MarcFormat marcFormat) {
+    return super.canProcess(field, marcFormat) && marcFormat == MarcFormat.AUTHORITY;
+  }
+
+  private Optional<UUID> extractAuthorityId(List<Subfield> subfields) {
+    return subfields.stream()
+      .filter(subfield -> subfield.getCode() == AUTHORITY_ID_SUBFIELD_CODE)
+      .filter(subfield -> MarcUtils.isValidUuid(subfield.getData()))
+      .map(subfield -> UUID.fromString(subfield.getData()))
+      .findFirst();
+  }
+}

--- a/src/main/java/org/folio/qm/converter/field/dto/AuthorityDataFieldConverter.java
+++ b/src/main/java/org/folio/qm/converter/field/dto/AuthorityDataFieldConverter.java
@@ -25,7 +25,7 @@ public class AuthorityDataFieldConverter extends CommonDataFieldConverter {
 
   @Override
   public boolean canProcess(VariableField field, MarcFormat marcFormat) {
-    return super.canProcess(field, marcFormat) && marcFormat == MarcFormat.AUTHORITY;
+    return field instanceof DataField && marcFormat == MarcFormat.AUTHORITY;
   }
 
   private Optional<UUID> extractAuthorityId(List<Subfield> subfields) {

--- a/src/main/java/org/folio/qm/converter/field/dto/CommonDataFieldConverter.java
+++ b/src/main/java/org/folio/qm/converter/field/dto/CommonDataFieldConverter.java
@@ -5,13 +5,10 @@ import static org.folio.qm.converter.elements.Constants.BLANK_REPLACEMENT;
 import static org.folio.qm.converter.elements.Constants.SPACE_CHARACTER;
 
 import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import org.folio.qm.converter.field.VariableFieldConverter;
 import org.folio.qm.domain.dto.FieldItem;
 import org.folio.qm.domain.dto.MarcFormat;
-import org.folio.qm.util.MarcUtils;
 import org.marc4j.marc.DataField;
 import org.marc4j.marc.Leader;
 import org.marc4j.marc.Subfield;
@@ -21,18 +18,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class CommonDataFieldConverter implements VariableFieldConverter<DataField> {
 
-  private static final char AUTHORITY_ID_SUBFIELD_CODE = '9';
-
   @Override
   public FieldItem convert(DataField field, Leader leader) {
-    var fieldItem = new FieldItem().tag(field.getTag())
+    return new FieldItem().tag(field.getTag())
       .addIndicatorsItem(convertIndicator(field.getIndicator1()))
       .addIndicatorsItem(convertIndicator(field.getIndicator2()))
       .content(convertSubfields(field.getSubfields()));
-
-    extractAuthorityId(field.getSubfields()).ifPresent(fieldItem::setAuthorityId);
-
-    return fieldItem;
   }
 
   @Override
@@ -50,13 +41,5 @@ public class CommonDataFieldConverter implements VariableFieldConverter<DataFiel
 
   private String convertIndicator(char ind) {
     return ind == SPACE_CHARACTER ? BLANK_REPLACEMENT : Character.toString(ind);
-  }
-
-  private Optional<UUID> extractAuthorityId(List<Subfield> subfields) {
-    return subfields.stream()
-      .filter(subfield -> subfield.getCode() == AUTHORITY_ID_SUBFIELD_CODE)
-      .filter(subfield -> MarcUtils.isValidUuid(subfield.getData()))
-      .map(subfield -> UUID.fromString(subfield.getData()))
-      .findFirst();
   }
 }

--- a/src/main/java/org/folio/qm/converter/field/dto/CommonDataFieldConverter.java
+++ b/src/main/java/org/folio/qm/converter/field/dto/CommonDataFieldConverter.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 import org.folio.qm.converter.field.VariableFieldConverter;
 import org.folio.qm.domain.dto.FieldItem;
 import org.folio.qm.domain.dto.MarcFormat;
+import org.folio.qm.util.MarcUtils;
 import org.marc4j.marc.DataField;
 import org.marc4j.marc.Leader;
 import org.marc4j.marc.Subfield;
@@ -54,17 +55,8 @@ public class CommonDataFieldConverter implements VariableFieldConverter<DataFiel
   private Optional<UUID> extractAuthorityId(List<Subfield> subfields) {
     return subfields.stream()
       .filter(subfield -> subfield.getCode() == AUTHORITY_ID_SUBFIELD_CODE)
-      .filter(subfield -> isValidUuid(subfield.getData()))
+      .filter(subfield -> MarcUtils.isValidUuid(subfield.getData()))
       .map(subfield -> UUID.fromString(subfield.getData()))
       .findFirst();
-  }
-
-  private boolean isValidUuid(String id) {
-    try {
-      UUID.fromString(id);
-      return true;
-    } catch (Exception ex) {
-      return false;
-    }
   }
 }

--- a/src/main/java/org/folio/qm/converter/field/dto/CommonDataFieldConverter.java
+++ b/src/main/java/org/folio/qm/converter/field/dto/CommonDataFieldConverter.java
@@ -28,7 +28,7 @@ public class CommonDataFieldConverter implements VariableFieldConverter<DataFiel
 
   @Override
   public boolean canProcess(VariableField field, MarcFormat marcFormat) {
-    return field instanceof DataField;
+    return field instanceof DataField && marcFormat != MarcFormat.AUTHORITY;
   }
 
   private String convertSubfields(List<Subfield> subfields) {

--- a/src/main/java/org/folio/qm/converter/field/dto/CommonDataFieldConverter.java
+++ b/src/main/java/org/folio/qm/converter/field/dto/CommonDataFieldConverter.java
@@ -54,12 +54,12 @@ public class CommonDataFieldConverter implements VariableFieldConverter<DataFiel
   private Optional<UUID> extractAuthorityId(List<Subfield> subfields) {
     return subfields.stream()
       .filter(subfield -> subfield.getCode() == AUTHORITY_ID_SUBFIELD_CODE)
-      .filter(subfield -> isValidUUID(subfield.getData()))
+      .filter(subfield -> isValidUuid(subfield.getData()))
       .map(subfield -> UUID.fromString(subfield.getData()))
       .findFirst();
   }
 
-  private boolean isValidUUID(String id) {
+  private boolean isValidUuid(String id) {
     try {
       UUID.fromString(id);
       return true;

--- a/src/main/java/org/folio/qm/converter/field/dto/CommonDataFieldConverter.java
+++ b/src/main/java/org/folio/qm/converter/field/dto/CommonDataFieldConverter.java
@@ -54,7 +54,17 @@ public class CommonDataFieldConverter implements VariableFieldConverter<DataFiel
   private Optional<UUID> extractAuthorityId(List<Subfield> subfields) {
     return subfields.stream()
       .filter(subfield -> subfield.getCode() == AUTHORITY_ID_SUBFIELD_CODE)
+      .filter(subfield -> isValidUUID(subfield.getData()))
       .map(subfield -> UUID.fromString(subfield.getData()))
       .findFirst();
+  }
+
+  private boolean isValidUUID(String id) {
+    try {
+      UUID.fromString(id);
+      return true;
+    } catch (Exception ex) {
+      return false;
+    }
   }
 }

--- a/src/main/java/org/folio/qm/util/MarcUtils.java
+++ b/src/main/java/org/folio/qm/util/MarcUtils.java
@@ -9,13 +9,15 @@ import com.google.common.collect.ImmutableBiMap;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import org.folio.qm.domain.dto.FieldItem;
 import org.folio.qm.domain.dto.MarcFormat;
 import org.folio.qm.domain.dto.ParsedRecordDto;
 import org.folio.qm.domain.dto.QuickMarc;
 
 public final class MarcUtils {
-
+  private static final Pattern UUID_REGEX =
+    Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
   public static final BiMap<ParsedRecordDto.RecordTypeEnum, MarcFormat> TYPE_MAP = ImmutableBiMap.of(
     ParsedRecordDto.RecordTypeEnum.BIB, MarcFormat.BIBLIOGRAPHIC,
     ParsedRecordDto.RecordTypeEnum.AUTHORITY, MarcFormat.AUTHORITY,
@@ -73,5 +75,9 @@ public final class MarcUtils {
 
   public static String masqueradeBlanks(String sourceString) {
     return sourceString.replace(SPACE, BLANK_REPLACEMENT);
+  }
+
+  public static boolean isValidUuid(String id) {
+    return UUID_REGEX.matcher(id).matches();
   }
 }

--- a/src/main/java/org/folio/qm/util/MarcUtils.java
+++ b/src/main/java/org/folio/qm/util/MarcUtils.java
@@ -16,16 +16,15 @@ import org.folio.qm.domain.dto.ParsedRecordDto;
 import org.folio.qm.domain.dto.QuickMarc;
 
 public final class MarcUtils {
-  private static final Pattern UUID_REGEX =
-    Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
   public static final BiMap<ParsedRecordDto.RecordTypeEnum, MarcFormat> TYPE_MAP = ImmutableBiMap.of(
     ParsedRecordDto.RecordTypeEnum.BIB, MarcFormat.BIBLIOGRAPHIC,
     ParsedRecordDto.RecordTypeEnum.AUTHORITY, MarcFormat.AUTHORITY,
     ParsedRecordDto.RecordTypeEnum.HOLDING, MarcFormat.HOLDINGS
   );
-
   private static final DateTimeFormatter DATE_AND_TIME_OF_LATEST_TRANSACTION_FIELD_FORMATTER =
     DateTimeFormatter.ofPattern("yyyyMMddHHmmss.S");
+  private static final Pattern UUID_REGEX =
+    Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
 
   private MarcUtils() {
   }

--- a/src/test/java/org/folio/qm/converter/field/dto/AuthorityDataFieldConverterTest.java
+++ b/src/test/java/org/folio/qm/converter/field/dto/AuthorityDataFieldConverterTest.java
@@ -1,6 +1,7 @@
 package org.folio.qm.converter.field.dto;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -9,6 +10,7 @@ import java.util.UUID;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.folio.qm.domain.dto.FieldItem;
+import org.folio.qm.domain.dto.MarcFormat;
 import org.folio.qm.support.types.UnitTest;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -18,38 +20,31 @@ import org.marc4j.marc.impl.DataFieldImpl;
 import org.marc4j.marc.impl.SubfieldImpl;
 
 @UnitTest
-class CommonDataFieldConverterTest {
+class AuthorityDataFieldConverterTest {
+  private final AuthorityDataFieldConverter converter = new AuthorityDataFieldConverter();
 
-  private final CommonDataFieldConverter converter = new CommonDataFieldConverter();
+  private static Stream<Arguments> cannotProcessFields() {
+    return Stream.of(
+      arguments(new DataFieldImpl("014", ' ', ' '), MarcFormat.BIBLIOGRAPHIC),
+      arguments(new DataFieldImpl("014", ' ', ' '), MarcFormat.HOLDINGS)
+    );
+  }
+
+  public static Stream<Arguments> dataFields() {
+    return IntStream.range(10, 999)
+      .mapToObj(value -> String.format("%03d", value))
+      .map(tag -> new DataFieldImpl(tag, '0', '0'))
+      .map(Arguments::arguments);
+  }
 
   private static Stream<Arguments> fieldData() {
     return Stream.of(
-      arguments(new DataFieldImpl("948", '1', '2'),
-        new String[] {"a", "1", "b", "a", "d", "b", "e", "2", "1", "3"},
-        new FieldItem().tag("948").indicators(List.of("1", "2")).content("$a 1 $b a $d b $e 2 $1 3")
-      ),
-      arguments(new DataFieldImpl("010", '1', '1'),
-        new String[] {"a", " 2001000234"},
-        new FieldItem().tag("010").indicators(List.of("1", "1")).content("$a  2001000234")
-      ),
-      arguments(new DataFieldImpl("010", '1', '1'),
-        new String[] {"a", "sn2003045678 "},
-        new FieldItem().tag("010").indicators(List.of("1", "1")).content("$a sn2003045678 ")
-      ),
-      arguments(new DataFieldImpl("010", '1', '1'),
-        new String[] {"a", "34005678 "},
-        new FieldItem().tag("010").indicators(List.of("1", "1")).content("$a 34005678 ")
-      ),
-      arguments(new DataFieldImpl("010", ' ', ' '),
-        new String[] {"a", "  34005678 /M"},
-        new FieldItem().tag("010").indicators(List.of("\\", "\\")).content("$a   34005678 /M")
-      ),
       arguments(new DataFieldImpl("010", ' ', ' '),
         new String[] {"a", "34005678", "9", "2c4750ae-fb1f-4f6f-8ef9-9ccd9ff1bf3b"},
         new FieldItem().tag("010")
           .indicators(List.of("\\", "\\"))
           .content("$a 34005678 $9 2c4750ae-fb1f-4f6f-8ef9-9ccd9ff1bf3b")
-          .authorityId(null)
+          .authorityId(UUID.fromString("2c4750ae-fb1f-4f6f-8ef9-9ccd9ff1bf3b"))
       ),
       arguments(new DataFieldImpl("014", '0', ' '),
         new String[] {"9", "not-valid-authority-uiid"},
@@ -59,13 +54,6 @@ class CommonDataFieldConverterTest {
           .authorityId(null)
       )
     );
-  }
-
-  public static Stream<Arguments> dataFields() {
-    return IntStream.range(10, 999)
-      .mapToObj(value -> String.format("%03d", value))
-      .map(tag -> new DataFieldImpl(tag, '0', '0'))
-      .map(Arguments::arguments);
   }
 
   @ParameterizedTest
@@ -79,8 +67,14 @@ class CommonDataFieldConverterTest {
   }
 
   @ParameterizedTest
+  @MethodSource("cannotProcessFields")
+  void testCannotProcessField(DataField field, MarcFormat format) {
+    assertFalse(converter.canProcess(field, format));
+  }
+
+  @ParameterizedTest
   @MethodSource("dataFields")
   void testCanProcessField(DataField dtoField) {
-    assertTrue(converter.canProcess(dtoField, null));
+    assertTrue(converter.canProcess(dtoField, MarcFormat.AUTHORITY));
   }
 }

--- a/src/test/java/org/folio/qm/converter/field/dto/CommonDataFieldConverterTest.java
+++ b/src/test/java/org/folio/qm/converter/field/dto/CommonDataFieldConverterTest.java
@@ -23,8 +23,8 @@ import org.marc4j.marc.impl.SubfieldImpl;
 @UnitTest
 class CommonDataFieldConverterTest {
 
-  private final CommonDataFieldConverter converter = new CommonDataFieldConverter();
   private static final MarcFormat[] BIB_AND_HOLDING_MARC = {HOLDINGS, BIBLIOGRAPHIC};
+  private final CommonDataFieldConverter converter = new CommonDataFieldConverter();
 
   private static Stream<Arguments> fieldData() {
     return Stream.of(

--- a/src/test/java/org/folio/qm/converter/field/dto/CommonDataFieldConverterTest.java
+++ b/src/test/java/org/folio/qm/converter/field/dto/CommonDataFieldConverterTest.java
@@ -50,6 +50,13 @@ class CommonDataFieldConverterTest {
           .indicators(List.of("\\", "\\"))
           .content("$a 34005678 $9 2c4750ae-fb1f-4f6f-8ef9-9ccd9ff1bf3b")
           .authorityId(UUID.fromString("2c4750ae-fb1f-4f6f-8ef9-9ccd9ff1bf3b"))
+      ),
+      arguments(new DataFieldImpl("014", '0', ' '),
+        new String[] {"9", "not-valid-authority-uiid"},
+        new FieldItem().tag("014")
+          .indicators(List.of("0", "\\"))
+          .content("$9 not-valid-authority-uiid")
+          .authorityId(null)
       )
     );
   }

--- a/src/test/java/org/folio/qm/converter/field/dto/CommonDataFieldConverterTest.java
+++ b/src/test/java/org/folio/qm/converter/field/dto/CommonDataFieldConverterTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.folio.qm.domain.dto.FieldItem;

--- a/src/test/java/org/folio/qm/converter/field/dto/CommonDataFieldConverterTest.java
+++ b/src/test/java/org/folio/qm/converter/field/dto/CommonDataFieldConverterTest.java
@@ -1,6 +1,9 @@
 package org.folio.qm.converter.field.dto;
 
+import static org.folio.qm.domain.dto.MarcFormat.BIBLIOGRAPHIC;
+import static org.folio.qm.domain.dto.MarcFormat.HOLDINGS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -8,6 +11,7 @@ import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.folio.qm.domain.dto.FieldItem;
+import org.folio.qm.domain.dto.MarcFormat;
 import org.folio.qm.support.types.UnitTest;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -20,7 +24,7 @@ import org.marc4j.marc.impl.SubfieldImpl;
 class CommonDataFieldConverterTest {
 
   private final CommonDataFieldConverter converter = new CommonDataFieldConverter();
-
+  private final static MarcFormat[] BIB_AND_HOLDING_MARC = {HOLDINGS, BIBLIOGRAPHIC};
   private static Stream<Arguments> fieldData() {
     return Stream.of(
       arguments(new DataFieldImpl("948", '1', '2'),
@@ -80,6 +84,12 @@ class CommonDataFieldConverterTest {
   @ParameterizedTest
   @MethodSource("dataFields")
   void testCanProcessField(DataField dtoField) {
-    assertTrue(converter.canProcess(dtoField, null));
+    assertTrue(converter.canProcess(dtoField, BIB_AND_HOLDING_MARC[(int) Math.round(Math.random())]));
+  }
+
+  @ParameterizedTest
+  @MethodSource("dataFields")
+  void testCannotProcessField(DataField dtoField) {
+    assertFalse(converter.canProcess(dtoField, MarcFormat.AUTHORITY));
   }
 }

--- a/src/test/java/org/folio/qm/converter/field/dto/CommonDataFieldConverterTest.java
+++ b/src/test/java/org/folio/qm/converter/field/dto/CommonDataFieldConverterTest.java
@@ -24,7 +24,8 @@ import org.marc4j.marc.impl.SubfieldImpl;
 class CommonDataFieldConverterTest {
 
   private final CommonDataFieldConverter converter = new CommonDataFieldConverter();
-  private final static MarcFormat[] BIB_AND_HOLDING_MARC = {HOLDINGS, BIBLIOGRAPHIC};
+  private static final MarcFormat[] BIB_AND_HOLDING_MARC = {HOLDINGS, BIBLIOGRAPHIC};
+
   private static Stream<Arguments> fieldData() {
     return Stream.of(
       arguments(new DataFieldImpl("948", '1', '2'),

--- a/src/test/java/org/folio/qm/util/MarcUtilsTest.java
+++ b/src/test/java/org/folio/qm/util/MarcUtilsTest.java
@@ -1,0 +1,20 @@
+package org.folio.qm.util;
+
+import java.util.UUID;
+import org.folio.qm.support.types.UnitTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+class MarcUtilsTest {
+
+  @Test
+  void whenUUIDIsValid_thenValidationSucceeds() {
+    Assertions.assertTrue(MarcUtils.isValidUuid(UUID.randomUUID().toString()));
+  }
+
+  @Test
+  void whenUUIDIsInvalid_thenValidationFails() {
+    Assertions.assertFalse(MarcUtils.isValidUuid("invalid-uuid"));
+  }
+}

--- a/src/test/java/org/folio/qm/util/MarcUtilsTest.java
+++ b/src/test/java/org/folio/qm/util/MarcUtilsTest.java
@@ -9,12 +9,12 @@ import org.junit.jupiter.api.Test;
 class MarcUtilsTest {
 
   @Test
-  void whenUUIDIsValid_thenValidationSucceeds() {
+  void whenUuidIsValid_thenValidationSucceeds() {
     Assertions.assertTrue(MarcUtils.isValidUuid(UUID.randomUUID().toString()));
   }
 
   @Test
-  void whenUUIDIsInvalid_thenValidationFails() {
+  void whenUuidIsInvalid_thenValidationFails() {
     Assertions.assertFalse(MarcUtils.isValidUuid("invalid-uuid"));
   }
 }


### PR DESCRIPTION
## Purpose
If any "MARC" record has "$9" subfield in any field in "invalid UUID format" user can't open this "MARC" record. The "500" error is displayed.

## Approach
_Invalid authority UUIDs can be skipped during GET request_

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
https://issues.folio.org/browse/MODQM-296