### PR TITLE
MODQM-304 Fix processing of authority links

### DIFF
--- a/src/main/java/org/folio/qm/converter/field/dto/BibliographicDataFieldConverter.java
+++ b/src/main/java/org/folio/qm/converter/field/dto/BibliographicDataFieldConverter.java
@@ -13,7 +13,7 @@ import org.marc4j.marc.VariableField;
 import org.springframework.stereotype.Component;
 
 @Component
-public class AuthorityDataFieldConverter extends CommonDataFieldConverter {
+public class BibliographicDataFieldConverter extends CommonDataFieldConverter {
   private static final char AUTHORITY_ID_SUBFIELD_CODE = '9';
 
   @Override
@@ -25,7 +25,7 @@ public class AuthorityDataFieldConverter extends CommonDataFieldConverter {
 
   @Override
   public boolean canProcess(VariableField field, MarcFormat marcFormat) {
-    return field instanceof DataField && marcFormat == MarcFormat.AUTHORITY;
+    return field instanceof DataField && marcFormat == MarcFormat.BIBLIOGRAPHIC;
   }
 
   private Optional<UUID> extractAuthorityId(List<Subfield> subfields) {

--- a/src/main/java/org/folio/qm/converter/field/dto/CommonDataFieldConverter.java
+++ b/src/main/java/org/folio/qm/converter/field/dto/CommonDataFieldConverter.java
@@ -28,7 +28,7 @@ public class CommonDataFieldConverter implements VariableFieldConverter<DataFiel
 
   @Override
   public boolean canProcess(VariableField field, MarcFormat marcFormat) {
-    return field instanceof DataField && marcFormat != MarcFormat.AUTHORITY;
+    return field instanceof DataField && marcFormat != MarcFormat.BIBLIOGRAPHIC;
   }
 
   private String convertSubfields(List<Subfield> subfields) {

--- a/src/test/java/org/folio/qm/converter/field/dto/BibliographicDataFieldConverterTest.java
+++ b/src/test/java/org/folio/qm/converter/field/dto/BibliographicDataFieldConverterTest.java
@@ -20,12 +20,12 @@ import org.marc4j.marc.impl.DataFieldImpl;
 import org.marc4j.marc.impl.SubfieldImpl;
 
 @UnitTest
-class AuthorityDataFieldConverterTest {
-  private final AuthorityDataFieldConverter converter = new AuthorityDataFieldConverter();
+class BibliographicDataFieldConverterTest {
+  private final BibliographicDataFieldConverter converter = new BibliographicDataFieldConverter();
 
   private static Stream<Arguments> cannotProcessFields() {
     return Stream.of(
-      arguments(new DataFieldImpl("014", ' ', ' '), MarcFormat.BIBLIOGRAPHIC),
+      arguments(new DataFieldImpl("014", ' ', ' '), MarcFormat.AUTHORITY),
       arguments(new DataFieldImpl("014", ' ', ' '), MarcFormat.HOLDINGS)
     );
   }
@@ -75,6 +75,6 @@ class AuthorityDataFieldConverterTest {
   @ParameterizedTest
   @MethodSource("dataFields")
   void testCanProcessField(DataField dtoField) {
-    assertTrue(converter.canProcess(dtoField, MarcFormat.AUTHORITY));
+    assertTrue(converter.canProcess(dtoField, MarcFormat.BIBLIOGRAPHIC));
   }
 }

--- a/src/test/java/org/folio/qm/converter/field/dto/CommonDataFieldConverterTest.java
+++ b/src/test/java/org/folio/qm/converter/field/dto/CommonDataFieldConverterTest.java
@@ -1,6 +1,6 @@
 package org.folio.qm.converter.field.dto;
 
-import static org.folio.qm.domain.dto.MarcFormat.BIBLIOGRAPHIC;
+import static org.folio.qm.domain.dto.MarcFormat.AUTHORITY;
 import static org.folio.qm.domain.dto.MarcFormat.HOLDINGS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -23,7 +23,7 @@ import org.marc4j.marc.impl.SubfieldImpl;
 @UnitTest
 class CommonDataFieldConverterTest {
 
-  private static final MarcFormat[] BIB_AND_HOLDING_MARC = {HOLDINGS, BIBLIOGRAPHIC};
+  private static final MarcFormat[] SUPPORTED_FORMATS = {HOLDINGS, AUTHORITY};
   private final CommonDataFieldConverter converter = new CommonDataFieldConverter();
 
   private static Stream<Arguments> fieldData() {
@@ -85,12 +85,12 @@ class CommonDataFieldConverterTest {
   @ParameterizedTest
   @MethodSource("dataFields")
   void testCanProcessField(DataField dtoField) {
-    assertTrue(converter.canProcess(dtoField, BIB_AND_HOLDING_MARC[(int) Math.round(Math.random())]));
+    assertTrue(converter.canProcess(dtoField, SUPPORTED_FORMATS[(int) Math.round(Math.random())]));
   }
 
   @ParameterizedTest
   @MethodSource("dataFields")
   void testCannotProcessField(DataField dtoField) {
-    assertFalse(converter.canProcess(dtoField, MarcFormat.AUTHORITY));
+    assertFalse(converter.canProcess(dtoField, MarcFormat.BIBLIOGRAPHIC));
   }
 }


### PR DESCRIPTION
## Purpose
Fix processing of authority links

## Approach
Links should be processed only for bibliographic fields, not authority fields

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.
