### PR TITLE
MODQM-314 Add linkingRuleId to request/response bodies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <records-editor.yaml.file>${project.basedir}/src/main/resources/swagger.api/records-editor.yaml</records-editor.yaml.file>
     <records-editor-async.yaml.file>${project.basedir}/src/main/resources/swagger.api/records-editor-async.yaml</records-editor-async.yaml.file>
 
-    <folio-spring-base.version>6.0.0-SNAPSHOT</folio-spring-base.version>
+    <folio-spring-base.version>6.0.1</folio-spring-base.version>
     <openapi-generator.version>6.2.1</openapi-generator.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
     <commons-lang.version>2.6</commons-lang.version>

--- a/src/main/java/org/folio/qm/client/LinksClient.java
+++ b/src/main/java/org/folio/qm/client/LinksClient.java
@@ -42,5 +42,6 @@ public interface LinksClient {
     UUID instanceId;
     String bibRecordTag;
     List<String> bibRecordSubfields;
+    Integer linkingRuleId;
   }
 }

--- a/src/main/java/org/folio/qm/service/impl/LinksServiceImpl.java
+++ b/src/main/java/org/folio/qm/service/impl/LinksServiceImpl.java
@@ -1,6 +1,5 @@
 package org.folio.qm.service.impl;
 
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.folio.qm.client.LinksClient;
 import org.folio.qm.client.LinksClient.InstanceLink;
@@ -49,8 +48,9 @@ public class LinksServiceImpl implements LinksService {
         .setAuthorityId(fieldItem.getAuthorityId())
         .setAuthorityNaturalId(fieldItem.getAuthorityNaturalId())
         .setBibRecordTag(fieldItem.getTag())
-        .setBibRecordSubfields(fieldItem.getAuthorityControlledSubfields()))
-      .collect(Collectors.toList());
+        .setBibRecordSubfields(fieldItem.getAuthorityControlledSubfields())
+        .setLinkingRuleId(fieldItem.getLinkingRuleId()))
+      .toList();
 
     return new InstanceLinks(links, links.size());
   }
@@ -59,7 +59,7 @@ public class LinksServiceImpl implements LinksService {
     instanceLinks.getLinks().forEach(instanceLink -> {
       var fields = qmRecord.getFields().stream()
         .filter(fieldItem -> instanceLink.getBibRecordTag().equals(fieldItem.getTag()))
-        .collect(Collectors.toList());
+        .toList();
 
       if (fields.size() == 1) {
         populateLink(fields.get(0), instanceLink);
@@ -75,5 +75,6 @@ public class LinksServiceImpl implements LinksService {
     fieldItem.setAuthorityId(instanceLink.getAuthorityId());
     fieldItem.setAuthorityNaturalId(instanceLink.getAuthorityNaturalId());
     fieldItem.setAuthorityControlledSubfields(instanceLink.getBibRecordSubfields());
+    fieldItem.setLinkingRuleId(instanceLink.getLinkingRuleId());
   }
 }

--- a/src/main/resources/swagger.api/schemas/fieldItem.json
+++ b/src/main/resources/swagger.api/schemas/fieldItem.json
@@ -50,6 +50,10 @@
       },
       "minItems": 1,
       "maxItems": 100
+    },
+    "linkingRuleId": {
+      "description": "Linking rule ID by which the link was created",
+      "type": "integer"
     }
   },
   "required": [

--- a/src/test/java/org/folio/qm/service/impl/LinksServiceImplTest.java
+++ b/src/test/java/org/folio/qm/service/impl/LinksServiceImplTest.java
@@ -33,8 +33,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @UnitTest
 @ExtendWith(MockitoExtension.class)
 class LinksServiceImplTest {
-  
+
   private static final String AUTHORITY_ID = "b9a5f035-de63-4e2c-92c2-07240c88b817";
+  private static final int LINKING_RULE_ID = 1;
 
   @Mock
   private LinksClient linksClient;
@@ -81,7 +82,7 @@ class LinksServiceImplTest {
   @ParameterizedTest
   @MethodSource("setLinksTestData")
   void testRecordLinksSet(List<InstanceLink> links, List<FieldItem> fieldItemsMock, Integer expectedLinkedFieldsCount) {
-    var instanceLinks = new InstanceLinks(links, 1);
+    var instanceLinks = new InstanceLinks(links, LINKING_RULE_ID);
 
     when(linksClient.fetchLinksByInstanceId(any())).thenReturn(Optional.of(instanceLinks));
 
@@ -130,7 +131,8 @@ class LinksServiceImplTest {
         .setAuthorityId(fieldItem.getAuthorityId())
         .setAuthorityNaturalId(fieldItem.getAuthorityNaturalId())
         .setBibRecordTag(fieldItem.getTag())
-        .setBibRecordSubfields(fieldItem.getAuthorityControlledSubfields()))
+        .setBibRecordSubfields(fieldItem.getAuthorityControlledSubfields())
+        .setLinkingRuleId(fieldItem.getLinkingRuleId()))
       .collect(Collectors.toList());
     var expectedInstanceLinks = new InstanceLinks(expectedLinks, expectedLinks.size());
 
@@ -164,7 +166,7 @@ class LinksServiceImplTest {
 
   private static FieldItem getFieldItemLinked() {
     return getFieldItem(AUTHORITY_ID).authorityNaturalId("12345")
-      .authorityControlledSubfields(List.of("a", "b", "c"));
+      .authorityControlledSubfields(List.of("a", "b", "c")).linkingRuleId(LINKING_RULE_ID);
   }
 
   private static InstanceLink getInstanceLink(UUID authorityId, List<String> subfields) {
@@ -173,7 +175,8 @@ class LinksServiceImplTest {
       "12345",
       UUID.fromString("b9a5f035-de63-4e2c-92c2-07240c89b817"),
       "650",
-      subfields);
+      subfields,
+      LINKING_RULE_ID);
   }
 
   private QuickMarc getQuickMarc(List<FieldItem> fieldItems) {


### PR DESCRIPTION
## Purpose
Add linkingRuleId to request/response bodies

## Approach
* Update request/response bodies with linkingRuleId

### Changes checklist
- [x] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.
