### PR TITLE
MODQM-315 BE - Edit/Derive a MARC bib - Support MARC LDR_19 values 'b' and 'c'

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## v3.1.0 xxxx-xx-xx
+
+### Features
+* Edit/Derive a MARC bib - Support MARC LDR_19 values 'b' and 'c' ([MODQM-315](https://issues.folio.org/browse/MODQM-315))
+
 ## v3.0.0 2023-02-22
 ### Breaking changes
 * Migration to Spring Boot v3.0.0 and Java 17 ([MODQM-302](https://issues.folio.org/browse/MODQM-302))

--- a/src/main/java/org/folio/qm/converter/elements/LeaderItem.java
+++ b/src/main/java/org/folio/qm/converter/elements/LeaderItem.java
@@ -2,7 +2,6 @@ package org.folio.qm.converter.elements;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public enum LeaderItem {
   //COMMON FIELDS FOR BIB, HOLDINGS AND AUTHORITY
@@ -27,7 +26,7 @@ public enum LeaderItem {
   BIBLIOGRAPHIC_LEVEL("Bibliographic level", 7, 1, 'a', 'b', 'c', 'd', 'i', 'm', 's'),
   CONTROL_TYPE("Type of control", 8, 1, '\\', ' ', '\u00A0', 'a'),
   CATALOGING_FORM("Descriptive cataloging form", 18, 1, '\\', ' ', '\u00A0', 'a', 'c', 'i', 'n', 'u'),
-  RESOURCE_RECORD_LEVEL("Multipart resource record level", 19, 1, '\\', ' ', '\u00A0', 'a'),
+  RESOURCE_RECORD_LEVEL("Multipart resource record level", 19, 1, '\\', ' ', '\u00A0', 'a', 'b', 'c'),
 
   // Deprecated in MODQM-164
   BIB_ENCODING_LEVEL("Bib encoding level", 17, 1, '\\', ' ', '\u00A0', '1', '2', '3', '4', '5', '7', '8', 'i', 'j', 'k',
@@ -54,7 +53,7 @@ public enum LeaderItem {
     this.name = name;
     this.position = position;
     this.length = length;
-    this.possibleValues = Arrays.stream(possibleValues).collect(Collectors.toList());
+    this.possibleValues = Arrays.stream(possibleValues).toList();
   }
 
   public String getName() {

--- a/src/test/java/org/folio/qm/validation/leader/BibliographicLeaderValidationRuleTest.java
+++ b/src/test/java/org/folio/qm/validation/leader/BibliographicLeaderValidationRuleTest.java
@@ -10,11 +10,12 @@ import org.folio.qm.validation.ValidationError;
 import org.folio.qm.validation.impl.bibliographic.BibliographicLeaderValidationRule;
 import org.hamcrest.core.Is;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @UnitTest
 class BibliographicLeaderValidationRuleTest {
 
-  private static final String VALID_LEADER = "01706ccm\\a2200361\\\\\\4500";
   private static final String WRONG_BIB_RECORD_STATUS = "01706xcm\\a2200361\\\\\\4500";
   private static final String WRONG_BIB_RECORD_TYPE = "01706cxm\\a2200361\\\\\\4500";
   private static final String WRONG_BIBLIOGRAPHIC_LEVEL = "01706ccx\\a2200361\\\\\\4500";
@@ -25,9 +26,15 @@ class BibliographicLeaderValidationRuleTest {
 
   private final BibliographicLeaderValidationRule rule = new BibliographicLeaderValidationRule();
 
-  @Test
-  void shouldValidateBibliographicLeaderWithoutErrors() {
-    var validationError = rule.validate(VALID_LEADER);
+  @ParameterizedTest
+  @ValueSource(strings = {"01706ccm\\a2200361\\\\\\4500",
+    "01706ccm\\a2200361\\\\ 4500",
+    "01706ccm\\a2200361\\\\\u00A04500",
+    "01706ccm\\a2200361\\\\a4500",
+    "01706ccm\\a2200361\\\\b4500",
+    "01706ccm\\a2200361\\\\c4500"})
+  void shouldValidateBibliographicLeaderWithoutErrors(String validLeader) {
+    var validationError = rule.validate(validLeader);
     assertTrue(validationError.isEmpty());
   }
 


### PR DESCRIPTION
## Purpose
Support MARC LDR_19 values 'b' and 'c' for MARC bib

## Approach
- add 'b' and 'c' to validation rule of bib's 19'th position

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### Learning
[MODQM-315](https://issues.folio.org/browse/MODQM-315)
