### PR TITLE
MODQM-323 Can't open imported "MARC Bib" record in "quickmarc"

### DIFF
--- a/src/main/java/org/folio/qm/client/LinkingRulesClient.java
+++ b/src/main/java/org/folio/qm/client/LinkingRulesClient.java
@@ -1,0 +1,22 @@
+package org.folio.qm.client;
+
+import java.util.List;
+import lombok.Data;
+import lombok.experimental.Accessors;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(value = "linking-rules", dismiss404 = true)
+public interface LinkingRulesClient {
+
+  @GetMapping(value = "instance-authority", produces = MediaType.APPLICATION_JSON_VALUE)
+  List<LinkingRuleDto> fetchLinkingRules();
+
+  @Data
+  @Accessors(chain = true)
+  class LinkingRuleDto {
+    private Integer id;
+    private String bibField;
+  }
+}

--- a/src/main/java/org/folio/qm/client/LinksClient.java
+++ b/src/main/java/org/folio/qm/client/LinksClient.java
@@ -23,9 +23,6 @@ public interface LinksClient {
   @PutMapping("/instances/{instanceId}")
   void putLinksByInstanceId(@PathVariable("instanceId") UUID instanceId, InstanceLinks instanceLinks);
 
-  @GetMapping(value = "/linking-rules/instance-authority", produces = MediaType.APPLICATION_JSON_VALUE)
-  List<LinkingRuleDto> fetchLinkingRules();
-
   @Value
   class InstanceLinks {
     List<InstanceLink> links;
@@ -42,11 +39,5 @@ public interface LinksClient {
     String authorityNaturalId;
     UUID instanceId;
     Integer linkingRuleId;
-  }
-
-  @Data
-  class LinkingRuleDto {
-    private Integer id;
-    private String bibField;
   }
 }

--- a/src/main/java/org/folio/qm/service/LinkingRulesService.java
+++ b/src/main/java/org/folio/qm/service/LinkingRulesService.java
@@ -1,9 +1,9 @@
 package org.folio.qm.service;
 
 import java.util.List;
-import org.folio.qm.client.LinksClient;
+import org.folio.qm.client.LinkingRulesClient;
 
 public interface LinkingRulesService {
 
-  List<LinksClient.LinkingRuleDto> getLinkingRules();
+  List<LinkingRulesClient.LinkingRuleDto> getLinkingRules();
 }

--- a/src/main/java/org/folio/qm/service/impl/LinkingRulesServiceImpl.java
+++ b/src/main/java/org/folio/qm/service/impl/LinkingRulesServiceImpl.java
@@ -4,7 +4,7 @@ import static org.folio.qm.config.CacheNames.QM_FETCH_LINKING_RULES_RESULTS;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.folio.qm.client.LinksClient;
+import org.folio.qm.client.LinkingRulesClient;
 import org.folio.qm.service.LinkingRulesService;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -13,13 +13,13 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class LinkingRulesServiceImpl implements LinkingRulesService {
 
-  private final LinksClient linksClient;
+  private final LinkingRulesClient linkingRulesClient;
 
   @Override
   @Cacheable(cacheNames = QM_FETCH_LINKING_RULES_RESULTS,
     key = "@folioExecutionContext.tenantId",
     unless = "#result.isEmpty()")
-  public List<LinksClient.LinkingRuleDto> getLinkingRules() {
-    return linksClient.fetchLinkingRules();
+  public List<LinkingRulesClient.LinkingRuleDto> getLinkingRules() {
+    return linkingRulesClient.fetchLinkingRules();
   }
 }

--- a/src/test/java/org/folio/qm/support/utils/ApiTestUtils.java
+++ b/src/test/java/org/folio/qm/support/utils/ApiTestUtils.java
@@ -29,7 +29,7 @@ public class ApiTestUtils {
   public static final String CHANGE_MANAGER_JOB_PROFILE_PATH = CHANGE_MANAGER_JOB_EXECUTION_PATH + "/%s/jobProfile";
   public static final String CHANGE_MANAGER_PARSE_RECORDS_PATH = CHANGE_MANAGER_JOB_EXECUTION_PATH + "/%s/records";
   public static final String FIELD_PROTECTION_SETTINGS_PATH = "/field-protection-settings/marc?limit=1000";
-  public static final String LINKING_RULES_FETCHING_PATH = "/links/linking-rules/instance-authority";
+  public static final String LINKING_RULES_FETCHING_PATH = "/linking-rules/instance-authority";
   public static final String USERS_PATH = "/users";
   public static final String LINKS_PATH = "/links";
   public static final String LINKS_INSTANCES_PATH = LINKS_PATH + "/instances";


### PR DESCRIPTION
## Purpose
Fix opening bib records in quick marc

## Approach
- Fix url for linking rules

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
[MODQM-323](https://issues.folio.org/browse/MODQM-323)
