### PR TITLE
fix(module-permission): Permission on marc-record edit for users

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -45,7 +45,8 @@
             "users.item.get",
             "converter-storage.field-protection-settings.get",
             "instance-authority-links.instances.collection.get",
-            "instance-authority.linking-rules.collection.get"
+            "instance-authority.linking-rules.collection.get",
+            "linking-rules.instance-authority.get"
           ]
         },
         {


### PR DESCRIPTION
## Purpose
_When clicking on "Edit" in Marc Authority/ MARC Holdings, an error message is displayed_

## Approach
_A small change is implemented in the ModuleDescriptor.json file._

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [x] Permissions changed, added, or removed
- [ ] Check logging.
