### PR TITLE
MODQM-336: Migrated folio-spring-base to v7.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <records-editor.yaml.file>${project.basedir}/src/main/resources/swagger.api/records-editor.yaml</records-editor.yaml.file>
     <records-editor-async.yaml.file>${project.basedir}/src/main/resources/swagger.api/records-editor-async.yaml</records-editor-async.yaml.file>
 
-    <folio-spring-base.version>6.1.0</folio-spring-base.version>
+    <folio-spring-base.version>7.0.0</folio-spring-base.version>
     <openapi-generator.version>6.5.0</openapi-generator.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
     <commons-lang.version>2.6</commons-lang.version>


### PR DESCRIPTION
## Purpose
Migrate to folio-spring-support v7.0.0

## Approach
If the module is not required to have CQL support then just update folio-spring-base dependency to v7.0.0 

If the module is required to have CQL support:
1. update folio-spring-base dependency to v7.0.0 
2. add new dependency

`<dependency>
<groupId>org.folio</groupId>
<artifactId>folio-spring-cql</artifactId>
<version>7.0.0</version>
</dependency> `
3. Change usage of `findByCQL` method to `findByCql` 

Because module is not required to have CQL support, only **folio-spring-base** dependency updated

### Learning
[MODQM-336](https://issues.folio.org/browse/MODQM-336)