### PR TITLE
MODQM-335 Change `records-editor.records` interface name to follow na…

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -33,8 +33,8 @@
   ],
   "provides": [
     {
-      "id": "records-editor.records",
-      "version": "4.0",
+      "id": "records-editor",
+      "version": "5.0",
       "handlers": [
         {
           "methods": ["GET"],


### PR DESCRIPTION
Purpose:
Change `records-editor.records` interface name to follow naming convention https://dev.folio.org/guidelines/naming-conventions/#interfaces

Requirements:
    Change interface name and bump major version





