### PR TITLE
MODQM-341 Set 'entered' date when empty on 008 field for bibs/holdings

### DIFF
--- a/src/main/java/org/folio/qm/converter/field/qm/Tag008BibliographicFieldItemConverter.java
+++ b/src/main/java/org/folio/qm/converter/field/qm/Tag008BibliographicFieldItemConverter.java
@@ -6,6 +6,7 @@ import static org.folio.qm.converter.elements.Constants.SPECIFIC_ELEMENTS_END_IN
 import static org.folio.qm.converter.elements.Constants.TAG_006_CONTROL_FIELD_LENGTH;
 import static org.folio.qm.converter.elements.Constants.TAG_008_BIBLIOGRAPHIC_CONTROL_FIELD_LENGTH;
 import static org.folio.qm.converter.elements.Constants.TAG_008_CONTROL_FIELD;
+import static org.folio.qm.converter.elements.ControlFieldItem.ENTERED;
 import static org.folio.qm.converter.elements.Tag008Configuration.getCommonItems;
 import static org.folio.qm.util.MarcUtils.restoreBlanks;
 
@@ -13,7 +14,6 @@ import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 import org.folio.qm.converter.elements.ControlFieldItem;
 import org.folio.qm.converter.elements.Tag008Configuration;
-import org.folio.qm.converter.field.FieldItemConverter;
 import org.folio.qm.domain.dto.FieldItem;
 import org.folio.qm.domain.dto.MarcFormat;
 import org.marc4j.marc.VariableField;
@@ -21,7 +21,7 @@ import org.marc4j.marc.impl.ControlFieldImpl;
 import org.springframework.stereotype.Component;
 
 @Component
-public class Tag008BibliographicFieldItemConverter implements FieldItemConverter {
+public class Tag008BibliographicFieldItemConverter extends Tag008FieldItemConverter {
 
   @Override
   public VariableField convert(FieldItem field) {
@@ -39,6 +39,7 @@ public class Tag008BibliographicFieldItemConverter implements FieldItemConverter
     var type = contentMap.get(ControlFieldItem.TYPE.getName()).toString().charAt(0);
     var blvl = contentMap.get(BLVL).toString().charAt(0);
 
+    setDateEntered(ENTERED.getName(), contentMap);
     var itemConfig = Tag008Configuration.resolveContentType(type, blvl);
     var specificItemsString = getSpecificItemsString(contentMap, itemConfig);
     var commonItemsString = getCommonItemsString(contentMap);

--- a/src/main/java/org/folio/qm/converter/field/qm/Tag008FieldItemConverter.java
+++ b/src/main/java/org/folio/qm/converter/field/qm/Tag008FieldItemConverter.java
@@ -1,0 +1,20 @@
+package org.folio.qm.converter.field.qm;
+
+import static org.apache.commons.lang.StringUtils.isBlank;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Map;
+import org.folio.qm.converter.field.FieldItemConverter;
+
+public abstract class Tag008FieldItemConverter implements FieldItemConverter {
+
+  private final SimpleDateFormat dateEnteredFormat = new SimpleDateFormat("yyMMdd");
+
+  protected void setDateEntered(String key, Map<String, Object> contentMap) {
+    var contentValue = contentMap.get(key);
+    if (contentValue == null || contentValue instanceof String enteredDate && isBlank(enteredDate)) {
+      contentMap.put(key, dateEnteredFormat.format(Calendar.getInstance().getTime()));
+    }
+  }
+}

--- a/src/main/java/org/folio/qm/converter/field/qm/Tag008HoldingsFieldItemConverter.java
+++ b/src/main/java/org/folio/qm/converter/field/qm/Tag008HoldingsFieldItemConverter.java
@@ -3,11 +3,11 @@ package org.folio.qm.converter.field.qm;
 import static org.folio.qm.converter.elements.Constants.HOLDINGS_CONTROL_FIELD_ITEMS;
 import static org.folio.qm.converter.elements.Constants.TAG_008_CONTROL_FIELD;
 import static org.folio.qm.converter.elements.Constants.TAG_008_HOLDINGS_CONTROL_FIELD_LENGTH;
+import static org.folio.qm.converter.elements.ControlFieldItem.DATE_ENTERED;
 import static org.folio.qm.util.MarcUtils.restoreBlanks;
 
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
-import org.folio.qm.converter.field.FieldItemConverter;
 import org.folio.qm.domain.dto.FieldItem;
 import org.folio.qm.domain.dto.MarcFormat;
 import org.marc4j.marc.VariableField;
@@ -15,7 +15,7 @@ import org.marc4j.marc.impl.ControlFieldImpl;
 import org.springframework.stereotype.Component;
 
 @Component
-public class Tag008HoldingsFieldItemConverter implements FieldItemConverter {
+public class Tag008HoldingsFieldItemConverter extends Tag008FieldItemConverter {
 
   @Override
   public VariableField convert(FieldItem field) {
@@ -30,6 +30,8 @@ public class Tag008HoldingsFieldItemConverter implements FieldItemConverter {
   private String restoreControlField(@NotNull Object content) {
     @SuppressWarnings("unchecked")
     var contentMap = (Map<String, Object>) content;
+
+    setDateEntered(DATE_ENTERED.getName(), contentMap);
     return restoreFixedLengthField(contentMap, TAG_008_HOLDINGS_CONTROL_FIELD_LENGTH, 0, HOLDINGS_CONTROL_FIELD_ITEMS);
   }
 }

--- a/src/test/java/org/folio/qm/converter/field/dto/Tag008BibliographicControlFieldConverterTest.java
+++ b/src/test/java/org/folio/qm/converter/field/dto/Tag008BibliographicControlFieldConverterTest.java
@@ -33,7 +33,7 @@ class Tag008BibliographicControlFieldConverterTest {
   @ParameterizedTest
   @EnumSource(value = Tag008FieldTestData.class,
               mode = EnumSource.Mode.EXCLUDE,
-              names = {"HOLDINGS", "HOLDINGS_WITH_GT_LEN", "HOLDINGS_WITH_LT_LEN",
+              names = {"HOLDINGS", "HOLDINGS_NO_DATE_ENTERED", "HOLDINGS_WITH_GT_LEN", "HOLDINGS_WITH_LT_LEN",
                        "AUTHORITY", "AUTHORITY_WITH_GT_LEN", "AUTHORITY_WITH_LT_LEN"})
   void testConvertField(Tag008FieldTestData testData) {
     var controlField = new ControlFieldImpl("008", testData.getDtoData());

--- a/src/test/java/org/folio/qm/converter/field/qm/Tag008BibliographicFieldItemConverterTest.java
+++ b/src/test/java/org/folio/qm/converter/field/qm/Tag008BibliographicFieldItemConverterTest.java
@@ -21,7 +21,7 @@ class Tag008BibliographicFieldItemConverterTest {
   @ParameterizedTest
   @EnumSource(value = Tag008FieldTestData.class,
               mode = EnumSource.Mode.EXCLUDE,
-              names = {"HOLDINGS", "HOLDINGS_WITH_GT_LEN", "HOLDINGS_WITH_LT_LEN",
+              names = {"HOLDINGS", "HOLDINGS_NO_DATE_ENTERED", "HOLDINGS_WITH_GT_LEN", "HOLDINGS_WITH_LT_LEN",
                        "AUTHORITY", "AUTHORITY_WITH_GT_LEN", "AUTHORITY_WITH_LT_LEN",
                        "BIB_BOOKS_WITH_LT_LEN"})
   void testConvertField(Tag008FieldTestData testData) {

--- a/src/test/java/org/folio/qm/converter/field/qm/Tag008HoldingsFieldItemConverterTest.java
+++ b/src/test/java/org/folio/qm/converter/field/qm/Tag008HoldingsFieldItemConverterTest.java
@@ -9,6 +9,8 @@ import org.folio.qm.domain.dto.MarcFormat;
 import org.folio.qm.support.types.UnitTest;
 import org.folio.qm.support.utils.testdata.Tag008FieldTestData;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.marc4j.marc.ControlField;
 
 @UnitTest
@@ -16,11 +18,14 @@ class Tag008HoldingsFieldItemConverterTest {
 
   private final Tag008HoldingsFieldItemConverter converter = new Tag008HoldingsFieldItemConverter();
 
-  @Test
-  void testConvertField() {
-    var fieldItem = new FieldItem().tag("008").content(Tag008FieldTestData.HOLDINGS.getQmContent());
+  @ParameterizedTest
+  @EnumSource(value = Tag008FieldTestData.class,
+    mode = EnumSource.Mode.INCLUDE,
+    names = {"HOLDINGS", "HOLDINGS_NO_DATE_ENTERED"})
+  void testConvertField(Tag008FieldTestData testData) {
+    var fieldItem = new FieldItem().tag("008").content(testData.getQmContent());
     var actualQmField = converter.convert(fieldItem);
-    assertEquals(Tag008FieldTestData.HOLDINGS.getDtoData(), ((ControlField) actualQmField).getData());
+    assertEquals(testData.getDtoData(), ((ControlField) actualQmField).getData());
   }
 
   @Test

--- a/src/test/java/org/folio/qm/support/utils/testdata/Tag008FieldTestData.java
+++ b/src/test/java/org/folio/qm/support/utils/testdata/Tag008FieldTestData.java
@@ -1,5 +1,7 @@
 package org.folio.qm.support.utils.testdata;
 
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -7,6 +9,7 @@ import java.util.Map;
 public enum Tag008FieldTestData {
 
   BIB_BOOKS("abcdefghijklmnopqrabcdefghijklmn opstuvw", "00158caa a2200073   4500", getBooksContent()),
+  BIB_BOOKS_NO_DATE_ENTERED(getCurrentDate() + "ghijklmnopqrabcdefghijklmn opstuvw", "00158caa a2200073   4500", getBooksNoDateEnteredContent()),
   BIB_BOOKS_WITH_EMPTY_ITEMS("abcdefghijklmnopqrabcde     klmn opstuvw", "00158caa a2200073   4500",
     getBooksWithEmptyItemsContent()),
   BIB_BOOKS_WITH_LT_LEN("abcdefgh", "00158caa a2200073   4500", getBooksWithLtLenContent()),
@@ -19,6 +22,7 @@ public enum Tag008FieldTestData {
   BIB_UNKNOWN("abcdefghijklmnopqrabcdefghijklmnopqstuvw", "00158cha a2200073   4500", getUnknownContent()),
   BIB_VISUAL("abcdefghijklmnopqrabc d     ef   ghstuvw", "00158cga a2200073   4500", getVisualContent()),
   HOLDINGS("9301235u    8   0   uu     1    ", "00158cga a2200073   4500", getHoldingsContent()),
+  HOLDINGS_NO_DATE_ENTERED(getCurrentDate() + "5u    8   0   uu     1    ", "00158cga a2200073   4500", getHoldingsNoDateEnteredContent()),
   HOLDINGS_WITH_LT_LEN("9301235u", "00158cga a2200073   4500", getHoldingsLtLenContent()),
   HOLDINGS_WITH_GT_LEN("9301235u    8   0   uu     1    qwerty", "00158cga a2200073   4500", getHoldingsContent()),
   AUTHORITY("810824n| azannaabn   a      |b aaa      ", "00158cga a2200073   4500", getAuthorityContent()),
@@ -34,6 +38,10 @@ public enum Tag008FieldTestData {
     this.dtoData = dtoData;
     this.leader = leader;
     this.qmContent = qmContent;
+  }
+
+  private static String getCurrentDate() {
+    return new SimpleDateFormat("yyMMdd").format(Calendar.getInstance().getTime());
   }
 
   private static Map<String, Object> getAuthorityContent() {
@@ -110,6 +118,23 @@ public enum Tag008FieldTestData {
     return content;
   }
 
+  private static Map<String, Object> getHoldingsNoDateEnteredContent() {
+    Map<String, Object> content = new LinkedHashMap<>();
+    content.put("AcqStatus", "5");
+    content.put("AcqMethod", "u");
+    content.put("AcqEndDate", "\\\\\\\\");
+    content.put("Compl", "0");
+    content.put("Copies", "\\\\\\");
+    content.put("Gen ret", "8");
+    content.put("Lang", "\\\\\\");
+    content.put("Lend", "u");
+    content.put("Repro", "u");
+    content.put("Rept date", "\\1\\\\\\\\");
+    content.put("Sep/comp", "\\");
+    content.put("Spec ret", List.of("\\", "\\", "\\"));
+    return content;
+  }
+
   private static Map<String, Object> getHoldingsLtLenContent() {
     Map<String, Object> content = new LinkedHashMap<>();
     content.put("AcqStatus", "5");
@@ -133,6 +158,30 @@ public enum Tag008FieldTestData {
     content.put("Type", "a");
     content.put("BLvl", "a");
     content.put("Entered", "abcdef");
+    content.put("DtSt", "g");
+    content.put("Date1", "hijk");
+    content.put("Date2", "lmno");
+    content.put("Ctry", "pqr");
+    content.put("Lang", "stu");
+    content.put("MRec", "v");
+    content.put("Srce", "w");
+    content.put("Ills", List.of("a", "b", "c", "d"));
+    content.put("Audn", "e");
+    content.put("Form", "f");
+    content.put("Cont", List.of("g", "h", "i", "j"));
+    content.put("GPub", "k");
+    content.put("Conf", "l");
+    content.put("Fest", "m");
+    content.put("Indx", "n");
+    content.put("LitF", "o");
+    content.put("Biog", "p");
+    return content;
+  }
+
+  private static Map<String, Object> getBooksNoDateEnteredContent() {
+    Map<String, Object> content = new LinkedHashMap<>();
+    content.put("Type", "a");
+    content.put("BLvl", "a");
     content.put("DtSt", "g");
     content.put("Date1", "hijk");
     content.put("Date2", "lmno");

--- a/src/test/java/org/folio/qm/support/utils/testdata/Tag008FieldTestData.java
+++ b/src/test/java/org/folio/qm/support/utils/testdata/Tag008FieldTestData.java
@@ -9,7 +9,8 @@ import java.util.Map;
 public enum Tag008FieldTestData {
 
   BIB_BOOKS("abcdefghijklmnopqrabcdefghijklmn opstuvw", "00158caa a2200073   4500", getBooksContent()),
-  BIB_BOOKS_NO_DATE_ENTERED(getCurrentDate() + "ghijklmnopqrabcdefghijklmn opstuvw", "00158caa a2200073   4500", getBooksNoDateEnteredContent()),
+  BIB_BOOKS_NO_DATE_ENTERED(getCurrentDate() + "ghijklmnopqrabcdefghijklmn opstuvw", "00158caa a2200073   4500",
+    getBooksNoDateEnteredContent()),
   BIB_BOOKS_WITH_EMPTY_ITEMS("abcdefghijklmnopqrabcde     klmn opstuvw", "00158caa a2200073   4500",
     getBooksWithEmptyItemsContent()),
   BIB_BOOKS_WITH_LT_LEN("abcdefgh", "00158caa a2200073   4500", getBooksWithLtLenContent()),
@@ -22,7 +23,8 @@ public enum Tag008FieldTestData {
   BIB_UNKNOWN("abcdefghijklmnopqrabcdefghijklmnopqstuvw", "00158cha a2200073   4500", getUnknownContent()),
   BIB_VISUAL("abcdefghijklmnopqrabc d     ef   ghstuvw", "00158cga a2200073   4500", getVisualContent()),
   HOLDINGS("9301235u    8   0   uu     1    ", "00158cga a2200073   4500", getHoldingsContent()),
-  HOLDINGS_NO_DATE_ENTERED(getCurrentDate() + "5u    8   0   uu     1    ", "00158cga a2200073   4500", getHoldingsNoDateEnteredContent()),
+  HOLDINGS_NO_DATE_ENTERED(getCurrentDate() + "5u    8   0   uu     1    ", "00158cga a2200073   4500",
+    getHoldingsNoDateEnteredContent()),
   HOLDINGS_WITH_LT_LEN("9301235u", "00158cga a2200073   4500", getHoldingsLtLenContent()),
   HOLDINGS_WITH_GT_LEN("9301235u    8   0   uu     1    qwerty", "00158cga a2200073   4500", getHoldingsContent()),
   AUTHORITY("810824n| azannaabn   a      |b aaa      ", "00158cga a2200073   4500", getAuthorityContent()),


### PR DESCRIPTION
## Purpose
Given user creates/edits/derives a MARC record. AND a 008 is added.
When user hits Save.
Then the first six positions (00-05) - Date entered on file must be 1.) system populated with the date the user created the record OR in cases of edit when user added the 008 field. 2.) this value should never change per MARC documentation. 3.) Populate in this format yymmdd is yy for the year, mm for the month, and dd for the day.

## Approach
- Add 'Entered' date filling to `Tag008BibliographicFieldItemConverter`
- Add 'Entered' date filling to `Tag008HoldingsFieldItemConverter`

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### Learning
[MODQM-341](https://issues.folio.org/browse/MODQM-341)
