### PR TITLE
fix(field-system-population): Set 'entered' date when absent/invalid on 008 field for authorities

### DIFF
--- a/src/main/java/org/folio/qm/converter/field/qm/Tag008AuthorityFieldItemConverter.java
+++ b/src/main/java/org/folio/qm/converter/field/qm/Tag008AuthorityFieldItemConverter.java
@@ -3,11 +3,11 @@ package org.folio.qm.converter.field.qm;
 import static org.folio.qm.converter.elements.Constants.AUTHORITY_CONTROL_FIELD_ITEMS;
 import static org.folio.qm.converter.elements.Constants.TAG_008_AUTHORITY_CONTROL_FIELD_LENGTH;
 import static org.folio.qm.converter.elements.Constants.TAG_008_CONTROL_FIELD;
+import static org.folio.qm.converter.elements.ControlFieldItem.DATE_ENTERED;
 import static org.folio.qm.util.MarcUtils.restoreBlanks;
 
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
-import org.folio.qm.converter.field.FieldItemConverter;
 import org.folio.qm.domain.dto.FieldItem;
 import org.folio.qm.domain.dto.MarcFormat;
 import org.marc4j.marc.VariableField;
@@ -15,7 +15,7 @@ import org.marc4j.marc.impl.ControlFieldImpl;
 import org.springframework.stereotype.Component;
 
 @Component
-public class Tag008AuthorityFieldItemConverter implements FieldItemConverter {
+public class Tag008AuthorityFieldItemConverter extends Tag008FieldItemConverter {
 
   @Override
   public VariableField convert(FieldItem field) {
@@ -30,6 +30,8 @@ public class Tag008AuthorityFieldItemConverter implements FieldItemConverter {
   private String restoreControlField(@NotNull Object content) {
     @SuppressWarnings("unchecked")
     var contentMap = (Map<String, Object>) content;
+    setDateEntered(DATE_ENTERED.getName(), contentMap);
+
     return restoreFixedLengthField(contentMap, TAG_008_AUTHORITY_CONTROL_FIELD_LENGTH, 0,
       AUTHORITY_CONTROL_FIELD_ITEMS);
   }

--- a/src/test/java/org/folio/qm/converter/field/dto/Tag008BibliographicControlFieldConverterTest.java
+++ b/src/test/java/org/folio/qm/converter/field/dto/Tag008BibliographicControlFieldConverterTest.java
@@ -37,7 +37,7 @@ class Tag008BibliographicControlFieldConverterTest {
     names = {"BIB_BOOKS_NO_DATE_ENTERED", "BIB_BOOKS_DATE_ENTERED_ALPHABETIC", "BIB_BOOKS_DATE_ENTERED_SHORT",
       "BIB_BOOKS_DATE_ENTERED_INVALID",
       "HOLDINGS", "HOLDINGS_NO_DATE_ENTERED", "HOLDINGS_WITH_GT_LEN", "HOLDINGS_WITH_LT_LEN",
-      "AUTHORITY", "AUTHORITY_WITH_GT_LEN", "AUTHORITY_WITH_LT_LEN"})
+      "AUTHORITY", "AUTHORITY_NO_DATE_ENTERED", "AUTHORITY_WITH_GT_LEN", "AUTHORITY_WITH_LT_LEN"})
   void testConvertField(Tag008FieldTestData testData) {
     var controlField = new ControlFieldImpl("008", testData.getDtoData());
     var leader = new LeaderImpl(testData.getLeader());

--- a/src/test/java/org/folio/qm/converter/field/qm/Tag008AuthorityFieldItemConverterTest.java
+++ b/src/test/java/org/folio/qm/converter/field/qm/Tag008AuthorityFieldItemConverterTest.java
@@ -9,6 +9,8 @@ import org.folio.qm.domain.dto.MarcFormat;
 import org.folio.qm.support.types.UnitTest;
 import org.folio.qm.support.utils.testdata.Tag008FieldTestData;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.marc4j.marc.ControlField;
 
 @UnitTest
@@ -16,11 +18,14 @@ class Tag008AuthorityFieldItemConverterTest {
 
   private final Tag008AuthorityFieldItemConverter converter = new Tag008AuthorityFieldItemConverter();
 
-  @Test
-  void testConvertField() {
-    var fieldItem = new FieldItem().tag("008").content(Tag008FieldTestData.AUTHORITY.getQmContent());
+  @ParameterizedTest
+  @EnumSource(value = Tag008FieldTestData.class,
+    mode = EnumSource.Mode.INCLUDE,
+    names = {"AUTHORITY", "AUTHORITY_NO_DATE_ENTERED"})
+  void testConvertField(Tag008FieldTestData testData) {
+    var fieldItem = new FieldItem().tag("008").content(testData.getQmContent());
     var actualQmField = converter.convert(fieldItem);
-    assertEquals(Tag008FieldTestData.AUTHORITY.getDtoData(), ((ControlField) actualQmField).getData());
+    assertEquals(testData.getDtoData(), ((ControlField) actualQmField).getData());
   }
 
   @Test

--- a/src/test/java/org/folio/qm/converter/field/qm/Tag008BibliographicFieldItemConverterTest.java
+++ b/src/test/java/org/folio/qm/converter/field/qm/Tag008BibliographicFieldItemConverterTest.java
@@ -22,7 +22,7 @@ class Tag008BibliographicFieldItemConverterTest {
   @EnumSource(value = Tag008FieldTestData.class,
               mode = EnumSource.Mode.EXCLUDE,
               names = {"HOLDINGS", "HOLDINGS_NO_DATE_ENTERED", "HOLDINGS_WITH_GT_LEN", "HOLDINGS_WITH_LT_LEN",
-                       "AUTHORITY", "AUTHORITY_WITH_GT_LEN", "AUTHORITY_WITH_LT_LEN",
+                       "AUTHORITY", "AUTHORITY_NO_DATE_ENTERED", "AUTHORITY_WITH_GT_LEN", "AUTHORITY_WITH_LT_LEN",
                        "BIB_BOOKS_WITH_LT_LEN"})
   void testConvertField(Tag008FieldTestData testData) {
     var actualQmField = converter.convert(new FieldItem().tag("007").content(testData.getQmContent()));

--- a/src/test/java/org/folio/qm/support/utils/testdata/Tag008FieldTestData.java
+++ b/src/test/java/org/folio/qm/support/utils/testdata/Tag008FieldTestData.java
@@ -34,6 +34,8 @@ public enum Tag008FieldTestData {
   HOLDINGS_WITH_LT_LEN("9301235u", "00158cga a2200073   4500", getHoldingsLtLenContent()),
   HOLDINGS_WITH_GT_LEN("9301235u    8   0   uu     1    qwerty", "00158cga a2200073   4500", getHoldingsContent()),
   AUTHORITY("810824n| azannaabn   a      |b aaa      ", "00158cga a2200073   4500", getAuthorityContent()),
+  AUTHORITY_NO_DATE_ENTERED(getCurrentDate() + "n| azannaabn   a      |b aaa      ", "00158cga a2200073   4500",
+    getAuthorityNoDateEntContent()),
   AUTHORITY_WITH_LT_LEN("810824n| ", "00158cga a2200073   4500", getAuthorityLtLenContent()),
   AUTHORITY_WITH_GT_LEN("810824n| azannaabn   a      |b aaa      dasdasdasdas", "00158cga a2200073   4500",
     getAuthorityContent());
@@ -52,9 +54,8 @@ public enum Tag008FieldTestData {
     return new SimpleDateFormat("yyMMdd").format(Calendar.getInstance().getTime());
   }
 
-  private static Map<String, Object> getAuthorityContent() {
+  private static Map<String, Object> getAuthorityNoDateEntContent() {
     Map<String, Object> content = new LinkedHashMap<>();
-    content.put("Date Ent", "810824");
     content.put("Geo Subd", "n");
     content.put("Roman", "|");
     content.put("Lang", "\\");
@@ -77,6 +78,12 @@ public enum Tag008FieldTestData {
     content.put("Undef_34", "\\\\\\\\");
     content.put("Mod Rec Est", "\\");
     content.put("Source", "\\");
+    return content;
+  }
+
+  private static Map<String, Object> getAuthorityContent() {
+    Map<String, Object> content = getAuthorityNoDateEntContent();
+    content.put("Date Ent", "810824");
     return content;
   }
 


### PR DESCRIPTION
## Purpose
Populate/fix "Date entered" in 008 field for authorities
[MODQM-346](https://issues.folio.org/browse/MODQM-346)

## Approach
- Add 'Entered' date population/correction to `Tag008AuthorityFieldItemConverter`

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.
