### PR TITLE
fix(automate-linking): missing subfields in response

### DIFF
--- a/.run/Tests-Integration.run.xml
+++ b/.run/Tests-Integration.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Tests-Integration" type="JUnit" factoryName="JUnit">
+    <module name="mod-quick-marc" />
+    <option name="PACKAGE_NAME" value="" />
+    <option name="METHOD_NAME" value="" />
+    <option name="TEST_OBJECT" value="tags" />
+    <tag value="integration" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/Tests-Unit.run.xml
+++ b/.run/Tests-Unit.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Tests-Unit" type="JUnit" factoryName="JUnit">
+    <module name="mod-quick-marc" />
+    <option name="PACKAGE_NAME" value="" />
+    <option name="METHOD_NAME" value="" />
+    <option name="TEST_OBJECT" value="tags" />
+    <tag value="unit" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,4 @@
 ## v5.0.0 xxxx-xx-xx
-### Features
-* Implement endpoint to suggest links for MARC-bibliographic record ([MODQM-319](https://issues.folio.org/browse/MODQM-330))
-
 ### Breaking changes
 * Update links interactions according to 'instance-authority-links' interface change to 2.0 ([MODQM-319](https://issues.folio.org/browse/MODQM-319))
 * Separate quickMarc schema for different actions ([MODQM-325](https://issues.folio.org/browse/MODQM-325))
@@ -14,7 +11,12 @@
 * Removed `_jsonSchemas`
 
 ### Features
+* Implement endpoint to suggest links for MARC-bibliographic record ([MODQM-319](https://issues.folio.org/browse/MODQM-330))
 * Edit/Derive a MARC bib - Support MARC LDR_19 values 'b' and 'c' ([MODQM-315](https://issues.folio.org/browse/MODQM-315))
+
+### Dependencies
+* Bump `spring-boot-starter-parent` from `3.0.2` to `3.1.1`
+* Bump `folio-spring-base` from `6.0.1` to `7.0.0`
 
 ## v3.0.0 2023-02-22
 ### Breaking changes

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.0.5</version>
+    <version>3.1.1</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
@@ -21,8 +21,9 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <records-editor.yaml.file>${project.basedir}/src/main/resources/swagger.api/records-editor.yaml</records-editor.yaml.file>
     <records-editor-async.yaml.file>${project.basedir}/src/main/resources/swagger.api/records-editor-async.yaml</records-editor-async.yaml.file>
+
     <folio-service-tools.version>3.1.0-SNAPSHOT</folio-service-tools.version>
-    <folio-spring-base.version>7.0.0</folio-spring-base.version>
+    <folio-spring-base.version>7.1.0</folio-spring-base.version>
     <openapi-generator.version>6.5.0</openapi-generator.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
     <commons-lang.version>2.6</commons-lang.version>
@@ -35,6 +36,7 @@
     <junit-extensions.version>2.6.0</junit-extensions.version>
     <jsonassert.version>1.5.1</jsonassert.version>
     <testcontainer.version>1.17.6</testcontainer.version>
+    <mockito.version>5.2.0</mockito.version>
 
     <sonar.exclusions>
       src/main/java/org/folio/qm/domain/entity/**,
@@ -142,6 +144,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -324,7 +327,8 @@
             </goals>
             <configuration>
               <sources>
-                <source>${project.build.directory}/generated-sources</source>
+                <source>${project.build.directory}/generated-sources/annotations</source>
+                <source>${project.build.directory}/generated-sources/src/main/java</source>
               </sources>
             </configuration>
           </execution>

--- a/src/main/java/org/folio/qm/converter/field/qm/AbstractFieldItemConverter.java
+++ b/src/main/java/org/folio/qm/converter/field/qm/AbstractFieldItemConverter.java
@@ -1,16 +1,7 @@
 package org.folio.qm.converter.field.qm;
 
-import static java.util.Objects.requireNonNull;
-import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.folio.qm.converter.elements.Constants.CONCAT_CONDITION_PATTERN;
-import static org.folio.qm.converter.elements.Constants.SPLIT_PATTERN;
-import static org.folio.qm.converter.elements.Constants.TOKEN_MIN_LENGTH;
+import static org.folio.qm.util.MarcUtils.extractSubfields;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.folio.qm.converter.field.FieldItemConverter;
 import org.folio.qm.domain.dto.FieldItem;
 import org.marc4j.marc.Subfield;
@@ -22,31 +13,8 @@ public abstract class AbstractFieldItemConverter implements FieldItemConverter {
   @Override
   public VariableField convert(FieldItem field) {
     var dataField = new DataFieldImpl(field.getTag(), getIndicator(field, 0), getIndicator(field, 1));
-    dataField.getSubfields().addAll(extractSubfields(field));
+    dataField.getSubfields().addAll(extractSubfields(field, this::subfieldFromString));
     return dataField;
-  }
-
-  private List<Subfield> extractSubfields(FieldItem field) {
-    var tokens = Arrays.stream(SPLIT_PATTERN.split(field.getContent().toString()))
-      .collect(Collectors.toCollection(LinkedList::new));
-
-    List<Subfield> subfields = new ArrayList<>();
-    while (!tokens.isEmpty()) {
-      String token = tokens.pop();
-      String subfieldString = token.concat(checkNextToken(tokens));
-      if (subfieldString.length() < TOKEN_MIN_LENGTH) {
-        throw new IllegalArgumentException("Subfield length");
-      }
-      subfields.add(subfieldFromString(subfieldString));
-    }
-
-    return subfields;
-  }
-
-  private String checkNextToken(LinkedList<String> tokens) {
-    return !tokens.isEmpty() && CONCAT_CONDITION_PATTERN.matcher(tokens.peek()).matches()
-      ? requireNonNull(tokens.poll()).concat(checkNextToken(tokens))
-      : EMPTY;
   }
 
   protected abstract Subfield subfieldFromString(String string);

--- a/src/test/java/org/folio/qm/mapper/LinksSuggestionsMapperTest.java
+++ b/src/test/java/org/folio/qm/mapper/LinksSuggestionsMapperTest.java
@@ -61,7 +61,7 @@ class LinksSuggestionsMapperTest {
     var quickMarcTag = "100";
     var quickMarcIndicators = List.of("1", "2");
     var linkDetails = new LinkDetails().status("ACTUAL");
-    var quickMarcContent = "$a test a subfield $0 test0 $9 test9";
+    var quickMarcContent = "$a test a subfield $0test0 $9 test9";
     var quickMarcField = new FieldItem()
       .tag(quickMarcTag)
       .linkDetails(linkDetails)


### PR DESCRIPTION
## Purpose
Fix record convertion that causes missing subfields in response

## Approach
- utilize common logic for string-to-subfields parsing

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### Learning
https://issues.folio.org/browse/MODQM-358
