### PR TITLE
feat(automate-linking): Add 'authoritySearchParameter' to links suggestion endpoint

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 * Add support of link status and errorCause ([MODQM-318](https://issues.folio.org/browse/MODQM-318))
 
 ### APIs versions
-* Provides `marc-records-editor` `v5.1`
+* Provides `marc-records-editor` `v5.2`
 * Removed `records-editor.records` `v4.0`
 * Requires `instance-authority-links` `v2.1`
 * Removed `_jsonSchemas`
@@ -13,6 +13,7 @@
 ### Features
 * Implement endpoint to suggest links for MARC-bibliographic record ([MODQM-319](https://issues.folio.org/browse/MODQM-330))
 * Edit/Derive a MARC bib - Support MARC LDR_19 values 'b' and 'c' ([MODQM-315](https://issues.folio.org/browse/MODQM-315))
+* Add "authoritySearchParameter" to "suggest links" endpoint ([MODQM-363](https://issues.folio.org/browse/MODQM-363))
 
 ### Dependencies
 * Bump `spring-boot-starter-parent` from `3.0.2` to `3.1.1`

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Spring-based module that provides API for quickMARC - in-app editor for MARC rec
 ## Additional information
 quickMARC API provides the following URLs:
 
-| Method | URL                                                    | Permissions                               | Description                                            | 
-|--------|--------------------------------------------------------|-------------------------------------------|--------------------------------------------------------|
-| GET    | /records-editor/records?externalId={externalId}        | marc-records-editor.item.get              | Retrieves QuickMarc by external id                     |
-| POST   | /records-editor/records                                | marc-records-editor.item.post             | Create a new MARC and Instance records                 |
-| PUT    | /records-editor/records/{recordId}                     | marc-records-editor.item.get              | Updates SRS record                                     |
-| GET    | /records-editor/records/status?qmRecordId={qmRecordId} | marc-records-editor.status.item.get       | Retrieves status of MARC bibliographic record creation |
-| POST   | /records-editor/links/suggestion                       | marc-records-editor.links.suggestion.post | Suggest links for record collection                    |
+| Method | URL                                                                       | Permissions                               | Description                                            | 
+|--------|---------------------------------------------------------------------------|-------------------------------------------|--------------------------------------------------------|
+| GET    | /records-editor/records?externalId={externalId}                           | marc-records-editor.item.get              | Retrieves QuickMarc by external id                     |
+| POST   | /records-editor/records                                                   | marc-records-editor.item.post             | Create a new MARC and Instance records                 |
+| PUT    | /records-editor/records/{recordId}                                        | marc-records-editor.item.get              | Updates SRS record                                     |
+| GET    | /records-editor/records/status?qmRecordId={qmRecordId}                    | marc-records-editor.status.item.get       | Retrieves status of MARC bibliographic record creation |
+| POST   | /records-editor/links/suggestion?authoritySearchParameter={ID/NATURAL_ID} | marc-records-editor.links.suggestion.post | Suggest links for record collection                    |
 
 More detail can be found on quickMARC wiki-page: [WIKI quickMARC](https://wiki.folio.org/pages/viewpage.action?pageId=36571766).
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -34,7 +34,7 @@
   "provides": [
     {
       "id": "marc-records-editor",
-      "version": "5.1",
+      "version": "5.2",
       "handlers": [
         {
           "methods": ["GET"],

--- a/src/main/java/org/folio/qm/client/LinksSuggestionsClient.java
+++ b/src/main/java/org/folio/qm/client/LinksSuggestionsClient.java
@@ -1,13 +1,16 @@
 package org.folio.qm.client;
 
+import org.folio.qm.domain.dto.AuthoritySearchParameter;
 import org.folio.qm.domain.dto.EntitiesLinksSuggestions;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(value = "links-suggestions", dismiss404 = true)
 public interface LinksSuggestionsClient {
 
   @PostMapping("/marc")
-  EntitiesLinksSuggestions postLinksSuggestions(EntitiesLinksSuggestions srsMarcRecord);
+  EntitiesLinksSuggestions postLinksSuggestions(EntitiesLinksSuggestions srsMarcRecord,
+                                                @RequestParam AuthoritySearchParameter authoritySearchParameter);
 
 }

--- a/src/main/java/org/folio/qm/controller/RecordsEditorApiImpl.java
+++ b/src/main/java/org/folio/qm/controller/RecordsEditorApiImpl.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpStatus.CREATED;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.folio.qm.domain.dto.AuthoritySearchParameter;
 import org.folio.qm.domain.dto.CreationStatus;
 import org.folio.qm.domain.dto.QuickMarcCreate;
 import org.folio.qm.domain.dto.QuickMarcView;
@@ -41,8 +42,9 @@ public class RecordsEditorApiImpl implements RecordsEditorApi {
   }
 
   @Override
-  public ResponseEntity<QuickMarcView> linksSuggestionPost(QuickMarcView quickMarcView) {
-    var quickMarc = marcRecordsService.suggestLinks(quickMarcView);
+  public ResponseEntity<QuickMarcView> linksSuggestionPost(QuickMarcView quickMarcView,
+                                                           AuthoritySearchParameter authoritySearchParameter) {
+    var quickMarc = marcRecordsService.suggestLinks(quickMarcView, authoritySearchParameter);
     return ResponseEntity.ok(quickMarc);
   }
 }

--- a/src/main/java/org/folio/qm/service/MarcRecordsService.java
+++ b/src/main/java/org/folio/qm/service/MarcRecordsService.java
@@ -1,6 +1,7 @@
 package org.folio.qm.service;
 
 import java.util.UUID;
+import org.folio.qm.domain.dto.AuthoritySearchParameter;
 import org.folio.qm.domain.dto.CreationStatus;
 import org.folio.qm.domain.dto.QuickMarcCreate;
 import org.folio.qm.domain.dto.QuickMarcEdit;
@@ -57,6 +58,6 @@ public interface MarcRecordsService {
    * @param quickMarcView QuickMarc object
    * @return {@link QuickMarcView} with suggested links
    */
-  QuickMarcView suggestLinks(QuickMarcView quickMarcView);
+  QuickMarcView suggestLinks(QuickMarcView quickMarcView, AuthoritySearchParameter authoritySearchParameter);
 }
 

--- a/src/main/java/org/folio/qm/service/impl/MarcRecordsServiceImpl.java
+++ b/src/main/java/org/folio/qm/service/impl/MarcRecordsServiceImpl.java
@@ -14,6 +14,7 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.qm.client.LinksSuggestionsClient;
 import org.folio.qm.client.UsersClient;
+import org.folio.qm.domain.dto.AuthoritySearchParameter;
 import org.folio.qm.domain.dto.BaseMarcRecord;
 import org.folio.qm.domain.dto.CreationStatus;
 import org.folio.qm.domain.dto.FieldItem;
@@ -124,10 +125,10 @@ public class MarcRecordsServiceImpl implements MarcRecordsService {
   }
 
   @Override
-  public QuickMarcView suggestLinks(QuickMarcView quickMarcView) {
+  public QuickMarcView suggestLinks(QuickMarcView quickMarcView, AuthoritySearchParameter authoritySearchParameter) {
     log.debug("suggestLinks:: trying to suggest links");
     var srsRecords = linksSuggestionsMapper.map(List.of(quickMarcView));
-    var srsRecordsWithSuggestions = linksSuggestionsClient.postLinksSuggestions(srsRecords);
+    var srsRecordsWithSuggestions = linksSuggestionsClient.postLinksSuggestions(srsRecords, authoritySearchParameter);
     var quickMarcRecordsWithSuggestions = linksSuggestionsMapper.map(srsRecordsWithSuggestions);
     if (isNotEmpty(quickMarcRecordsWithSuggestions)) {
       log.info("suggestLinks:: links was suggested");

--- a/src/main/resources/swagger.api/records-editor.yaml
+++ b/src/main/resources/swagger.api/records-editor.yaml
@@ -127,6 +127,13 @@ paths:
     post:
       tags:
         - records-editor
+      parameters:
+        - name: authoritySearchParameter
+          in: query
+          required: false
+          description: Authority field to search by
+          schema:
+            $ref: "#/components/schemas/AuthoritySearchParameter"
       responses:
         '201':
           description: MARC Record status created
@@ -178,4 +185,9 @@ components:
       $ref: schemas/external/marcFieldProtectionSettingsCollection.json
     dataImportEventPayload:
       $ref: schemas/external/dataImportEventPayload.json
+    AuthoritySearchParameter:
+      description: Authority search parameter for link suggestions
+      type: string
+      enum: [ID, NATURAL_ID]
+      default: NATURAL_ID
 


### PR DESCRIPTION
## Purpose
Add 'authoritySearchParameter' to links suggestion endpoint
[MODQM-363](https://issues.folio.org/browse/MODQM-363)

## Approach
Add 'authoritySearchParameter' to links suggestion endpoint and pass to mod-entities-links API

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.
