### PR TITLE
fix: update hypersistence dependency to supported by Hibernate 6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.6</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
@@ -24,20 +24,20 @@
     <marc-specifications.yaml.file>${project.basedir}/src/main/resources/swagger.api/marc-specifications.yaml</marc-specifications.yaml.file>
 
     <folio-service-tools.version>3.1.0</folio-service-tools.version>
-    <folio-spring-base.version>7.2.0</folio-spring-base.version>
-    <hypersistence-utils-hibernate-60.version>3.5.3</hypersistence-utils-hibernate-60.version>
-    <openapi-generator.version>7.0.1</openapi-generator.version>
+    <folio-spring-base.version>7.2.2</folio-spring-base.version>
+    <hypersistence-utils-hibernate-62.version>3.6.1</hypersistence-utils-hibernate-62.version>
+    <openapi-generator.version>7.1.0</openapi-generator.version>
     <mapstruct.version>1.5.5.Final</mapstruct.version>
     <commons-lang.version>2.6</commons-lang.version>
     <lombok.mapstruct-binding.version>0.2.0</lombok.mapstruct-binding.version>
-    <swagger-annotations.version>2.2.16</swagger-annotations.version>
+    <swagger-annotations.version>2.2.19</swagger-annotations.version>
 
     <!-- Test properties-->
     <wiremock.version>3.0.1</wiremock.version>
     <marc4j.version>2.9.5</marc4j.version>
     <junit-extensions.version>2.6.0</junit-extensions.version>
     <jsonassert.version>1.5.1</jsonassert.version>
-    <testcontainer.version>1.19.1</testcontainer.version>
+    <testcontainer.version>1.19.3</testcontainer.version>
     <mockito.version>5.2.0</mockito.version>
 
     <sonar.exclusions>
@@ -47,12 +47,12 @@
     </sonar.exclusions>
 
     <!-- Plugin properties -->
-    <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
+    <build-helper-maven-plugin.version>3.5.0</build-helper-maven-plugin.version>
     <copy-rename-maven-plugin.version>1.0.1</copy-rename-maven-plugin.version>
-    <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
-    <maven-failsafe-plugin.version>3.0.0-M7</maven-failsafe-plugin.version>
-    <maven-release-plugin.version>3.0.0-M7</maven-release-plugin.version>
-    <maven-checkstyle-plugin.version>3.2.0</maven-checkstyle-plugin.version>
+    <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
+    <maven-failsafe-plugin.version>3.2.2</maven-failsafe-plugin.version>
+    <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
+    <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
   </properties>
 
   <dependencies>
@@ -68,8 +68,8 @@
     </dependency>
     <dependency>
       <groupId>io.hypersistence</groupId>
-      <artifactId>hypersistence-utils-hibernate-60</artifactId>
-      <version>${hypersistence-utils-hibernate-60.version}</version>
+      <artifactId>hypersistence-utils-hibernate-62</artifactId>
+      <version>${hypersistence-utils-hibernate-62.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/org/folio/qm/domain/entity/JobProfile.java
+++ b/src/main/java/org/folio/qm/domain/entity/JobProfile.java
@@ -1,5 +1,6 @@
 package org.folio.qm.domain.entity;
 
+import io.hypersistence.utils.hibernate.type.basic.PostgreSQLEnumType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.Hibernate;
+import org.hibernate.annotations.Type;
 import org.hibernate.validator.constraints.Length;
 
 @Entity
@@ -39,11 +41,13 @@ public class JobProfile {
   @NotNull
   @Column(name = "profile_action", nullable = false)
   @Enumerated(EnumType.STRING)
+  @Type(PostgreSQLEnumType.class)
   private JobProfileAction profileAction;
 
   @NotNull
   @Column(name = "record_type", nullable = false)
   @Enumerated(EnumType.STRING)
+  @Type(PostgreSQLEnumType.class)
   private RecordType recordType;
 
   @Override

--- a/src/main/java/org/folio/qm/domain/entity/MarcSpecification.java
+++ b/src/main/java/org/folio/qm/domain/entity/MarcSpecification.java
@@ -1,5 +1,6 @@
 package org.folio.qm.domain.entity;
 
+import io.hypersistence.utils.hibernate.type.basic.PostgreSQLEnumType;
 import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -31,6 +32,7 @@ public class MarcSpecification {
 
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
+  @Type(PostgreSQLEnumType.class)
   private RecordType recordType;
 
   @Column(nullable = false)

--- a/src/main/java/org/folio/qm/domain/entity/RecordCreationStatus.java
+++ b/src/main/java/org/folio/qm/domain/entity/RecordCreationStatus.java
@@ -1,5 +1,6 @@
 package org.folio.qm.domain.entity;
 
+import io.hypersistence.utils.hibernate.type.basic.PostgreSQLEnumType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.Hibernate;
+import org.hibernate.annotations.Type;
 
 @Entity
 @Getter
@@ -31,6 +33,7 @@ public class RecordCreationStatus {
 
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
+  @Type(PostgreSQLEnumType.class)
   private RecordCreationStatusEnum status;
 
   private String errorMessage;


### PR DESCRIPTION
## Purpose
Update hypersistence-utils-hibernate to new version
Update defining enums in enttities to use library above
Update spring version to the latest

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.