### PR TITLE
MODQM-379 refactor(00X fields positions): Allow for any MARC field 00X to be moved up and down

### DIFF
--- a/src/main/java/org/folio/qm/converter/field/qm/AbstractFieldItemConverter.java
+++ b/src/main/java/org/folio/qm/converter/field/qm/AbstractFieldItemConverter.java
@@ -15,14 +15,14 @@ public abstract class AbstractFieldItemConverter implements FieldItemConverter {
   @Override
   public VariableField convert(FieldItem field) {
     var tag = field.getTag();
-    String data = getFieldData(field);
+    var data = getFieldData(field);
     return new ControlFieldImpl(tag, data);
   }
 
   @NotNull
   private String getFieldData(FieldItem field) {
-    String indicator1 = String.valueOf(getIndicator(field, 0));
-    String indicator2 = String.valueOf(getIndicator(field, 1));
+    var indicator1 = String.valueOf(getIndicator(field, 0));
+    var indicator2 = String.valueOf(getIndicator(field, 1));
     var indicators = indicator1 + indicator2;
 
     var content = extractSubfields(field, this::subfieldFromString).stream()

--- a/src/main/java/org/folio/qm/converter/field/qm/AbstractFieldItemConverter.java
+++ b/src/main/java/org/folio/qm/converter/field/qm/AbstractFieldItemConverter.java
@@ -2,19 +2,34 @@ package org.folio.qm.converter.field.qm;
 
 import static org.folio.qm.util.MarcUtils.extractSubfields;
 
+import java.util.stream.Collectors;
 import org.folio.qm.converter.field.FieldItemConverter;
 import org.folio.qm.domain.dto.FieldItem;
+import org.jetbrains.annotations.NotNull;
 import org.marc4j.marc.Subfield;
 import org.marc4j.marc.VariableField;
-import org.marc4j.marc.impl.DataFieldImpl;
+import org.marc4j.marc.impl.ControlFieldImpl;
 
 public abstract class AbstractFieldItemConverter implements FieldItemConverter {
 
   @Override
   public VariableField convert(FieldItem field) {
-    var dataField = new DataFieldImpl(field.getTag(), getIndicator(field, 0), getIndicator(field, 1));
-    dataField.getSubfields().addAll(extractSubfields(field, this::subfieldFromString));
-    return dataField;
+    var tag = field.getTag();
+    String data = getFieldData(field);
+    return new ControlFieldImpl(tag, data);
+  }
+
+  @NotNull
+  private String getFieldData(FieldItem field) {
+    String indicator1 = String.valueOf(getIndicator(field, 0));
+    String indicator2 = String.valueOf(getIndicator(field, 1));
+    var indicators = indicator1 + indicator2;
+
+    var content = extractSubfields(field, this::subfieldFromString).stream()
+      .map(subfield -> "$" + subfield.getCode() + subfield.getData())
+      .collect(Collectors.joining());
+
+    return indicators + content;
   }
 
   protected abstract Subfield subfieldFromString(String string);

--- a/src/test/java/org/folio/qm/converter/field/qm/Tag010FieldItemConverterTest.java
+++ b/src/test/java/org/folio/qm/converter/field/qm/Tag010FieldItemConverterTest.java
@@ -1,7 +1,6 @@
 package org.folio.qm.converter.field.qm;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
@@ -13,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.marc4j.marc.DataField;
+import org.marc4j.marc.ControlField;
 
 @UnitTest
 class Tag010FieldItemConverterTest {
@@ -22,15 +21,15 @@ class Tag010FieldItemConverterTest {
 
   private static Stream<Arguments> fieldData() {
     return Stream.of(
-      arguments("$a  2001000234", "  2001000234"),
-      arguments("$aa 2002003456  ", "a 2002003456"),
-      arguments("$a sn2003045678 ", "sn2003045678"),
-      arguments("$a 34005678", "   34005678 "),
-      arguments("$a   34005678 /M", "   34005678 /M"),
-      arguments("$ae  45000067 ", "e  45000067 "),
-      arguments("$a  sn 85000678 ", "sn 85000678 "),
-      arguments("$a agr25000003  ", "agr25000003 "),
-      arguments("$aagr25000003 /M", "agr25000003 /M")
+      arguments("$a  2001000234", "  $a  2001000234"),
+      arguments("$aa 2002003456  ", "  $aa 2002003456"),
+      arguments("$a sn2003045678 ", "  $asn2003045678"),
+      arguments("$a 34005678", "  $a   34005678 "),
+      arguments("$a   34005678 /M", "  $a   34005678 /M"),
+      arguments("$ae  45000067 ", "  $ae  45000067 "),
+      arguments("$a  sn 85000678 ", "  $asn 85000678 "),
+      arguments("$a agr25000003  ", "  $aagr25000003 "),
+      arguments("$aagr25000003 /M", "  $aagr25000003 /M")
     );
   }
 
@@ -41,12 +40,11 @@ class Tag010FieldItemConverterTest {
 
     assertThat(actualDtoField)
       .isNotNull()
-      .isInstanceOf(DataField.class);
+      .isInstanceOf(ControlField.class);
 
-    assertThat(((DataField) actualDtoField).getSubfields())
-      .hasSize(1)
-      .extracting("code", "data")
-      .containsExactly(tuple('a', dtoContent));
+    var controlField = (ControlField) actualDtoField;
+    assertThat(controlField.getTag()).isEqualTo("010");
+    assertThat(controlField.getData()).isEqualTo(dtoContent);
   }
 
   @Test


### PR DESCRIPTION
### Purpose
Allow for any MARC field 00X to be moved up and down when Creating/Deriving/Editing MARC records

### Approach
Mark all fields as "ControlFields" to enable the fields to move up and down.

### Changes Checklist
- [ ] **API Changes**: List any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Specify any database schema changes and their impact.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Note added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **NEWS**: Ensure that the `NEWS` file is updated with relevant information about the changes made in this pull request.

### Learning and Resources (if applicable)
https://issues.folio.org/browse/MODQM-379
