### PR TITLE
MODQM-406 Change item type from an array to a string for 008 field

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,13 +6,15 @@
 * Provides `API_NAME vX.Y`
 * Requires `API_NAME vX.Y`
 * Provides `marc-specifications` `v1.1`
+* Provides `marc-records-editor` `v5.4`
+
 
 ### Features
-* Update marc specification to support allowed values for 008 field positions ([MODQM-405](https://github.com/folio-org/mod-quick-marc/pull/244))
+* Update marc specification to support allowed values for 008 field positions ([MODQM-405](https://folio-org.atlassian.net/browse/MODQM-405))
 * support new Authority record creation ([MODQM-322](https://issues.folio.org/browse/MODQM-322)
 
 ### Bug fixes
-* Description ([ISSUE_NUMBER](https://issues.folio.org/browse/ISSUE_NUMBER))
+* Change item type from an array to a string for 008 field ([MODQM-406](https://folio-org.atlassian.net/browse/MODQM-406))
 
 ### Tech Dept
 * Description ([ISSUE_NUMBER](https://issues.folio.org/browse/ISSUE_NUMBER))

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -38,7 +38,7 @@
   "provides": [
     {
       "id": "marc-records-editor",
-      "version": "5.3",
+      "version": "5.4",
       "handlers": [
         {
           "methods": ["GET"],

--- a/src/main/java/org/folio/qm/converter/elements/ControlFieldItem.java
+++ b/src/main/java/org/folio/qm/converter/elements/ControlFieldItem.java
@@ -78,7 +78,7 @@ public enum ControlFieldItem {
   PRIMARY_SUPPORT("Primary support material", 4, 1, false),
   PRODUCTION_DETAILS("Production/reproduction details", 6, 1, false),
   PRODUCTION_ELEMENTS("Production elements", 9, 1, false),
-  PROJ("Proj", 5, 2, true),
+  PROJ("Proj", 5, 2, false),
   QUALITY_ASSURANCE_TARGET("Quality assurance target(s)", 10, 1, false),
   REDUCTION_RATIO("Reduction ratio range/Reduction ratio", 5, 4, false),
   REFINED_CATEGORIES("Refined categories of color", 13, 1, false),

--- a/src/test/java/org/folio/qm/support/utils/testdata/Tag006FieldTestData.java
+++ b/src/test/java/org/folio/qm/support/utils/testdata/Tag006FieldTestData.java
@@ -90,7 +90,7 @@ public enum Tag006FieldTestData {
     Map<String, Object> content = new LinkedHashMap<>();
     content.put("Type", "e");
     content.put("Relf", List.of("a", "b", "c", "d"));
-    content.put("Proj", List.of("e", "f"));
+    content.put("Proj", "ef");
     content.put("CrTp", "g");
     content.put("GPub", "h");
     content.put("Form", "i");

--- a/src/test/java/org/folio/qm/support/utils/testdata/Tag008FieldTestData.java
+++ b/src/test/java/org/folio/qm/support/utils/testdata/Tag008FieldTestData.java
@@ -326,7 +326,7 @@ public enum Tag008FieldTestData {
     content.put("MRec", "v");
     content.put("Srce", "w");
     content.put("Relf", List.of("a", "b", "c", "d"));
-    content.put("Proj", List.of("e", "f"));
+    content.put("Proj", "ef");
     content.put("CrTp", "g");
     content.put("GPub", "h");
     content.put("Form", "i");


### PR DESCRIPTION
### Purpose
There is an error in marc specification for item Projection (006/05-06) which is a part of maps specification for 008 field. Currently this item works like an array of values and should be a string. Change also will be done for 006 field because Projection item definition is common for 008 and 006.

### Approach
Change the item type from an array to a string for Proj MAPS item. (isArray=false)

### Changes Checklist
- change interface version
- update unit tests
- update NEWS

### Related Issues
https://folio-org.atlassian.net/browse/MODQM-406
https://folio-org.atlassian.net/browse/UIQM-636

