### PR TITLE
fix(validation): Don't throw an exception on empty field content during record convertion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 ### Bug fixes
 * Add Microfiche support to Form position for music and score document type ([MODQM-419](https://folio-org.atlassian.net/browse/MODQM-419))
 * Do not delete kafka topics if tenant collection topic feature is enabled ([MODQM-423](https://folio-org.atlassian.net/browse/MODQM-423))
+* Don't throw an exception on empty field content during record conversion on validation endpoint ([MODQM-438](https://folio-org.atlassian.net/browse/MODQM-438))
 
 ### Tech Dept
 * Description ([ISSUE_NUMBER](https://issues.folio.org/browse/ISSUE_NUMBER))

--- a/src/main/java/org/folio/qm/converter/MarcFieldsConverter.java
+++ b/src/main/java/org/folio/qm/converter/MarcFieldsConverter.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.folio.qm.converter.field.FieldItemConverter;
@@ -33,8 +32,17 @@ public class MarcFieldsConverter {
 
   public List<VariableField> convertQmFields(List<FieldItem> fields, MarcFormat format) {
     return fields.stream()
-      .map(field -> toVariableField(field, format))
-      .collect(Collectors.toList());
+      .map(field -> toVariableField(field, format, false))
+      .toList();
+  }
+
+  /**
+   * Convert Quick Marc fields in soft mode, ignoring invalid data.
+   * */
+  public List<VariableField> convertQmFieldsSoft(List<FieldItem> fields, MarcFormat format) {
+    return fields.stream()
+      .map(field -> toVariableField(field, format, true))
+      .toList();
   }
 
   public List<FieldItem> convertDtoFields(List<VariableField> fields, Leader leader, MarcFormat marcFormat) {
@@ -44,14 +52,14 @@ public class MarcFieldsConverter {
     var dataFields = fields.stream()
       .filter(DataField.class::isInstance)
       .map(field -> dataFieldToQuickMarcField((DataField) field, leader, marcFormat));
-    return Stream.concat(controlFields, dataFields).collect(Collectors.toList());
+    return Stream.concat(controlFields, dataFields).toList();
   }
 
-  public VariableField toVariableField(FieldItem field, MarcFormat marcFormat) {
+  public VariableField toVariableField(FieldItem field, MarcFormat marcFormat, boolean soft) {
     return fieldItemConverters.stream()
       .filter(fieldItemConverter -> fieldItemConverter.canProcess(field, marcFormat))
       .findFirst()
-      .map(fieldItemConverter -> fieldItemConverter.convert(field))
+      .map(fieldItemConverter -> fieldItemConverter.convert(field, soft))
       .orElseThrow(() -> new IllegalArgumentException("Field converter not found"));
   }
 

--- a/src/main/java/org/folio/qm/converter/MarcFieldsConverter.java
+++ b/src/main/java/org/folio/qm/converter/MarcFieldsConverter.java
@@ -19,29 +19,22 @@ import org.marc4j.marc.ControlField;
 import org.marc4j.marc.DataField;
 import org.marc4j.marc.Leader;
 import org.marc4j.marc.VariableField;
-import org.springframework.stereotype.Component;
 
-@Component
 @RequiredArgsConstructor
-public class MarcFieldsConverter {
+public abstract class MarcFieldsConverter {
 
   public static final String TAG_REGEX = "\\{(\\d{3})=([^}]+)";
+  /**
+   * Soft conversion means not throwing an exception in case of bad data, just ignore it.
+   * */
+  private final Boolean softConversion;
   private final List<FieldItemConverter> fieldItemConverters;
   private final List<VariableFieldConverter<DataField>> dataFieldConverters;
   private final List<VariableFieldConverter<ControlField>> controlFieldConverters;
 
   public List<VariableField> convertQmFields(List<FieldItem> fields, MarcFormat format) {
     return fields.stream()
-      .map(field -> toVariableField(field, format, false))
-      .toList();
-  }
-
-  /**
-   * Convert Quick Marc fields in soft mode, ignoring invalid data.
-   * */
-  public List<VariableField> convertQmFieldsSoft(List<FieldItem> fields, MarcFormat format) {
-    return fields.stream()
-      .map(field -> toVariableField(field, format, true))
+      .map(field -> toVariableField(field, format, softConversion))
       .toList();
   }
 

--- a/src/main/java/org/folio/qm/converter/MarcFieldsHardConverter.java
+++ b/src/main/java/org/folio/qm/converter/MarcFieldsHardConverter.java
@@ -1,0 +1,19 @@
+package org.folio.qm.converter;
+
+import java.util.List;
+import org.folio.qm.converter.field.FieldItemConverter;
+import org.folio.qm.converter.field.VariableFieldConverter;
+import org.marc4j.marc.ControlField;
+import org.marc4j.marc.DataField;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+@Primary
+@Component
+public class MarcFieldsHardConverter extends MarcFieldsConverter {
+  public MarcFieldsHardConverter(List<FieldItemConverter> fieldItemConverters,
+                                 List<VariableFieldConverter<DataField>> dataFieldConverters,
+                                 List<VariableFieldConverter<ControlField>> controlFieldConverters) {
+    super(false, fieldItemConverters, dataFieldConverters, controlFieldConverters);
+  }
+}

--- a/src/main/java/org/folio/qm/converter/MarcFieldsSoftConverter.java
+++ b/src/main/java/org/folio/qm/converter/MarcFieldsSoftConverter.java
@@ -1,0 +1,17 @@
+package org.folio.qm.converter;
+
+import java.util.List;
+import org.folio.qm.converter.field.FieldItemConverter;
+import org.folio.qm.converter.field.VariableFieldConverter;
+import org.marc4j.marc.ControlField;
+import org.marc4j.marc.DataField;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MarcFieldsSoftConverter extends MarcFieldsConverter {
+  public MarcFieldsSoftConverter(List<FieldItemConverter> fieldItemConverters,
+                                 List<VariableFieldConverter<DataField>> dataFieldConverters,
+                                 List<VariableFieldConverter<ControlField>> controlFieldConverters) {
+    super(true, fieldItemConverters, dataFieldConverters, controlFieldConverters);
+  }
+}

--- a/src/main/java/org/folio/qm/converter/MarcQmToMarcRecordConverter.java
+++ b/src/main/java/org/folio/qm/converter/MarcQmToMarcRecordConverter.java
@@ -33,7 +33,7 @@ public class MarcQmToMarcRecordConverter implements Converter<BaseMarcRecord, Ma
     List<MarcControlField> controlFields = new ArrayList<>();
     List<MarcDataField> dataFields = new ArrayList<>();
 
-    var fields = fieldsConverter.convertQmFields(source.getFields(), source.getMarcFormat()).stream()
+    var fields = fieldsConverter.convertQmFieldsSoft(source.getFields(), source.getMarcFormat()).stream()
       .collect(Collectors.groupingBy(VariableField::getTag));
 
     for (var entry : fields.entrySet()) {

--- a/src/main/java/org/folio/qm/converter/MarcQmToMarcRecordConverter.java
+++ b/src/main/java/org/folio/qm/converter/MarcQmToMarcRecordConverter.java
@@ -17,6 +17,7 @@ import org.marc4j.marc.ControlField;
 import org.marc4j.marc.DataField;
 import org.marc4j.marc.Subfield;
 import org.marc4j.marc.VariableField;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
@@ -26,6 +27,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class MarcQmToMarcRecordConverter implements Converter<BaseMarcRecord, MarcRecord> {
 
+  @Qualifier("marcFieldsSoftConverter")
   private final MarcFieldsConverter fieldsConverter;
 
   @Override
@@ -33,7 +35,7 @@ public class MarcQmToMarcRecordConverter implements Converter<BaseMarcRecord, Ma
     List<MarcControlField> controlFields = new ArrayList<>();
     List<MarcDataField> dataFields = new ArrayList<>();
 
-    var fields = fieldsConverter.convertQmFieldsSoft(source.getFields(), source.getMarcFormat()).stream()
+    var fields = fieldsConverter.convertQmFields(source.getFields(), source.getMarcFormat()).stream()
       .collect(Collectors.groupingBy(VariableField::getTag));
 
     for (var entry : fields.entrySet()) {

--- a/src/main/java/org/folio/qm/converter/field/FieldItemConverter.java
+++ b/src/main/java/org/folio/qm/converter/field/FieldItemConverter.java
@@ -20,6 +20,10 @@ public interface FieldItemConverter {
 
   VariableField convert(FieldItem field);
 
+  default VariableField convert(FieldItem field, boolean soft) {
+    return convert(field);
+  }
+
   boolean canProcess(FieldItem field, MarcFormat marcFormat);
 
   default char getIndicator(FieldItem field, int index) {

--- a/src/main/java/org/folio/qm/converter/field/qm/AbstractFieldItemConverter.java
+++ b/src/main/java/org/folio/qm/converter/field/qm/AbstractFieldItemConverter.java
@@ -12,8 +12,13 @@ public abstract class AbstractFieldItemConverter implements FieldItemConverter {
 
   @Override
   public VariableField convert(FieldItem field) {
+    return convert(field, false);
+  }
+
+  @Override
+  public VariableField convert(FieldItem field, boolean soft) {
     var dataField = new DataFieldImpl(field.getTag(), getIndicator(field, 0), getIndicator(field, 1));
-    dataField.getSubfields().addAll(extractSubfields(field, this::subfieldFromString));
+    dataField.getSubfields().addAll(extractSubfields(field, this::subfieldFromString, soft));
     return dataField;
   }
 

--- a/src/main/java/org/folio/qm/mapper/LinksSuggestionsMapper.java
+++ b/src/main/java/org/folio/qm/mapper/LinksSuggestionsMapper.java
@@ -88,7 +88,8 @@ public interface LinksSuggestionsMapper {
 
   default List<Map<String, String>> mapSubfields(FieldItem fieldItem) {
     var listOfSubfields = new ArrayList<Map<String, String>>();
-    var subfields = extractSubfields(fieldItem, s -> new SubfieldImpl(s.charAt(1), s.substring(2).trim()));
+    var subfields = extractSubfields(
+      fieldItem, s -> new SubfieldImpl(s.charAt(1), s.substring(2).trim()), false);
     for (var subfield : subfields) {
       listOfSubfields.add(Map.of(String.valueOf(subfield.getCode()), subfield.getData()));
     }

--- a/src/main/java/org/folio/qm/util/MarcUtils.java
+++ b/src/main/java/org/folio/qm/util/MarcUtils.java
@@ -94,14 +94,23 @@ public final class MarcUtils {
     return UUID_REGEX.matcher(id).matches();
   }
 
-  public static List<Subfield> extractSubfields(FieldItem field, Function<String, Subfield> subfieldFunction) {
+  /**
+   * Extract subfields from FieldItem.
+   *
+   * @param field Quick Marc field.
+   * @param subfieldFunction Function to map string to subfield object.
+   * @param soft Indicates whether to throw exception on invalid data. soft=true doesn't throw.
+   * */
+  public static List<Subfield> extractSubfields(FieldItem field, Function<String, Subfield> subfieldFunction,
+                                                boolean soft) {
     return Arrays.stream(SPLIT_PATTERN.split(field.getContent().toString()))
       .map(token -> {
-        if (token.length() < TOKEN_MIN_LENGTH) {
+        if (!soft && token.length() < TOKEN_MIN_LENGTH) {
           throw new IllegalArgumentException("Subfield length");
         }
         return token.replace(DOLLAR_EXPRESSION, "$");
       })
+      .filter(StringUtils::isNotBlank)
       .map(subfieldFunction)
       .toList();
   }

--- a/src/test/java/org/folio/qm/controller/RecordsEditorIT.java
+++ b/src/test/java/org/folio/qm/controller/RecordsEditorIT.java
@@ -134,12 +134,12 @@ class RecordsEditorIT extends BaseIT {
 
     postResultActions("/records-editor/validate", validatableRecord, Map.of())
       .andExpect(status().isOk())
-      .andExpect(jsonPath("$.issues.size()").value(1))
-      .andExpect(jsonPath("$.issues[0].tag").value("245[1]"))
-      .andExpect(jsonPath("$.issues[0].helpUrl").value("https://www.loc.gov/marc/bibliographic/bd245.html"))
-      .andExpect(jsonPath("$.issues[0].severity").value("error"))
-      .andExpect(jsonPath("$.issues[0].definitionType").value("field"))
-      .andExpect(jsonPath("$.issues[0].message").value(notNullValue()));
+      .andExpect(jsonPath("$.issues.size()").value(2))
+      .andExpect(jsonPath("$.issues[1].tag").value("245[1]"))
+      .andExpect(jsonPath("$.issues[1].helpUrl").value("https://www.loc.gov/marc/bibliographic/bd245.html"))
+      .andExpect(jsonPath("$.issues[1].severity").value("error"))
+      .andExpect(jsonPath("$.issues[1].definitionType").value("field"))
+      .andExpect(jsonPath("$.issues[1].message").value(notNullValue()));
   }
 
   @Test

--- a/src/test/java/org/folio/qm/controller/SpecificationKafkaListenerIT.java
+++ b/src/test/java/org/folio/qm/controller/SpecificationKafkaListenerIT.java
@@ -60,7 +60,7 @@ class SpecificationKafkaListenerIT extends BaseIT {
     var validatableRecord = readQuickMarc(QM_RECORD_VALIDATE_PATH, ValidatableRecord.class);
     postResultActions("/records-editor/validate", validatableRecord, Map.of())
       .andExpect(status().isOk())
-      .andExpect(jsonPath("$.issues.size()").value(1));
+      .andExpect(jsonPath("$.issues.size()").value(2));
 
     //update specification in cache with additional rules
     var specificationEvent = new SpecificationUpdatedEvent(
@@ -71,6 +71,6 @@ class SpecificationKafkaListenerIT extends BaseIT {
     await().atMost(FIVE_SECONDS).pollInterval(TWO_HUNDRED_MILLISECONDS).untilAsserted(() ->
       postResultActions("/records-editor/validate", validatableRecord, Map.of())
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.issues.size()").value(2)));
+        .andExpect(jsonPath("$.issues.size()").value(3)));
   }
 }

--- a/src/test/java/org/folio/qm/converter/MarcFieldsConverterTest.java
+++ b/src/test/java/org/folio/qm/converter/MarcFieldsConverterTest.java
@@ -1,0 +1,54 @@
+package org.folio.qm.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.LinkedList;
+import java.util.List;
+import org.folio.qm.converter.field.FieldItemConverter;
+import org.folio.qm.domain.dto.FieldItem;
+import org.folio.qm.domain.dto.MarcFormat;
+import org.folio.spring.testing.type.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.marc4j.marc.impl.DataFieldImpl;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class MarcFieldsConverterTest {
+
+  @Mock
+  private FieldItemConverter fieldItemConverter;
+
+  @Spy
+  private final List<FieldItemConverter> fieldItemConverters = new LinkedList<>();
+
+  @InjectMocks
+  private MarcFieldsConverter converter;
+
+  @BeforeEach
+  public void init() {
+    fieldItemConverters.add(fieldItemConverter);
+  }
+
+  @Test
+  void convertQmFieldsSoft() {
+    var fieldItem = new FieldItem();
+    var marcFormat = MarcFormat.BIBLIOGRAPHIC;
+    var expected = new DataFieldImpl("245", '/', '/');
+
+    when(fieldItemConverter.canProcess(fieldItem, marcFormat)).thenReturn(true);
+    when(fieldItemConverter.convert(fieldItem, true)).thenReturn(expected);
+
+    var actual = converter.convertQmFieldsSoft(List.of(fieldItem), marcFormat);
+
+    assertThat(actual).containsOnly(expected);
+    verify(fieldItemConverter).convert(fieldItem, true);
+  }
+}

--- a/src/test/java/org/folio/qm/converter/MarcFieldsSoftConverterTest.java
+++ b/src/test/java/org/folio/qm/converter/MarcFieldsSoftConverterTest.java
@@ -21,7 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
-class MarcFieldsConverterTest {
+class MarcFieldsSoftConverterTest {
 
   @Mock
   private FieldItemConverter fieldItemConverter;
@@ -30,7 +30,7 @@ class MarcFieldsConverterTest {
   private final List<FieldItemConverter> fieldItemConverters = new LinkedList<>();
 
   @InjectMocks
-  private MarcFieldsConverter converter;
+  private MarcFieldsSoftConverter converter;
 
   @BeforeEach
   public void init() {
@@ -46,7 +46,7 @@ class MarcFieldsConverterTest {
     when(fieldItemConverter.canProcess(fieldItem, marcFormat)).thenReturn(true);
     when(fieldItemConverter.convert(fieldItem, true)).thenReturn(expected);
 
-    var actual = converter.convertQmFieldsSoft(List.of(fieldItem), marcFormat);
+    var actual = converter.convertQmFields(List.of(fieldItem), marcFormat);
 
     assertThat(actual).containsOnly(expected);
     verify(fieldItemConverter).convert(fieldItem, true);

--- a/src/test/java/org/folio/qm/converter/MarcQmToMarcRecordConverterTest.java
+++ b/src/test/java/org/folio/qm/converter/MarcQmToMarcRecordConverterTest.java
@@ -1,0 +1,41 @@
+package org.folio.qm.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.folio.qm.domain.dto.BaseMarcRecord;
+import org.folio.spring.testing.type.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.marc4j.marc.impl.DataFieldImpl;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class MarcQmToMarcRecordConverterTest {
+
+  @Mock
+  private MarcFieldsConverter fieldsConverter;
+
+  @InjectMocks
+  private MarcQmToMarcRecordConverter converter;
+
+  @Test
+  void convert_emptyFieldContent() {
+    var source = new BaseMarcRecord().leader("test");
+    var tag = "245";
+
+    when(fieldsConverter.convertQmFieldsSoft(any(), any())).thenReturn(List.of(new DataFieldImpl(tag, '/', '/')));
+
+    var actual = converter.convert(source);
+
+    assertThat(actual).isNotNull();
+    assertThat(actual.dataFields()).hasSize(1);
+    assertThat(actual.dataFields().get(0))
+      .matches(field -> tag.equals(field.tag()) && field.subfields().isEmpty());
+  }
+}

--- a/src/test/java/org/folio/qm/converter/MarcQmToMarcRecordConverterTest.java
+++ b/src/test/java/org/folio/qm/converter/MarcQmToMarcRecordConverterTest.java
@@ -29,7 +29,7 @@ class MarcQmToMarcRecordConverterTest {
     var source = new BaseMarcRecord().leader("test");
     var tag = "245";
 
-    when(fieldsConverter.convertQmFieldsSoft(any(), any())).thenReturn(List.of(new DataFieldImpl(tag, '/', '/')));
+    when(fieldsConverter.convertQmFields(any(), any())).thenReturn(List.of(new DataFieldImpl(tag, '/', '/')));
 
     var actual = converter.convert(source);
 

--- a/src/test/java/org/folio/qm/converter/field/qm/CommonFieldItemConverterTest.java
+++ b/src/test/java/org/folio/qm/converter/field/qm/CommonFieldItemConverterTest.java
@@ -1,23 +1,32 @@
 package org.folio.qm.converter.field.qm;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.folio.qm.domain.dto.FieldItem;
+import org.folio.qm.util.MarcUtils;
 import org.folio.spring.testing.type.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.marc4j.marc.DataField;
 import org.marc4j.marc.impl.DataFieldImpl;
 import org.marc4j.marc.impl.SubfieldImpl;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @UnitTest
+@ExtendWith(MockitoExtension.class)
 class CommonFieldItemConverterTest {
 
   private final CommonFieldItemConverter converter = new CommonFieldItemConverter();
@@ -84,6 +93,28 @@ class CommonFieldItemConverterTest {
     }
     var actualDtoField = converter.convert(qmField);
     assertEquals(expectedDtoField.toString(), actualDtoField.toString());
+  }
+
+  @Test
+  void testConvert() {
+    var field = new FieldItem().tag("245");
+    try (var marcUtils = Mockito.mockStatic(MarcUtils.class)) {
+      var actual = converter.convert(field);
+      marcUtils.verify(() -> MarcUtils.extractSubfields(eq(field), any(), eq(false)));
+
+      assertThat(actual.getTag()).isEqualTo(field.getTag());
+    }
+  }
+
+  @Test
+  void testConvertSoft() {
+    var field = new FieldItem().tag("245");
+    try (var marcUtils = Mockito.mockStatic(MarcUtils.class)) {
+      var actual = converter.convert(field, true);
+      marcUtils.verify(() -> MarcUtils.extractSubfields(eq(field), any(), eq(true)));
+
+      assertThat(actual.getTag()).isEqualTo(field.getTag());
+    }
   }
 
   @ParameterizedTest

--- a/src/test/java/org/folio/qm/util/MarcUtilsTest.java
+++ b/src/test/java/org/folio/qm/util/MarcUtilsTest.java
@@ -1,5 +1,7 @@
 package org.folio.qm.util;
 
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -8,12 +10,14 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.UUID;
 import java.util.stream.Stream;
+import org.folio.qm.domain.dto.FieldItem;
 import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.marc4j.marc.impl.SubfieldImpl;
 
 @UnitTest
 class MarcUtilsTest {
@@ -55,6 +59,23 @@ class MarcUtilsTest {
 
     assertThrows(IllegalArgumentException.class,
       () -> MarcUtils.normalizeFixedLengthString(sourceString, length));
+  }
+
+  @Test
+  void extractSubfields_emptyFieldContent() {
+    var field = new FieldItem().content(EMPTY);
+
+    assertThrows(IllegalArgumentException.class,
+      () -> MarcUtils.extractSubfields(field, s -> new SubfieldImpl(), false));
+  }
+
+  @Test
+  void extractSubfields_emptyFieldContent_soft() {
+    var field = new FieldItem().content(EMPTY);
+
+    var subfields = MarcUtils.extractSubfields(field, s -> new SubfieldImpl(), true);
+
+    assertThat(subfields).isEmpty();
   }
 
 }

--- a/src/test/resources/mockdata/response/quickMarcValidate.json
+++ b/src/test/resources/mockdata/response/quickMarcValidate.json
@@ -43,6 +43,14 @@
       ]
     },
     {
+      "tag": "246",
+      "content": "",
+      "indicators": [
+        "2",
+        "0"
+      ]
+    },
+    {
       "tag": "998",
       "content": "$a Works",
       "indicators": [

--- a/src/test/resources/mockdata/response/specifications/specification.json
+++ b/src/test/resources/mockdata/response/specifications/specification.json
@@ -273,6 +273,57 @@
               ]
             }
           ]
+        },
+        {
+          "id": "f2b7ad73-8e82-4909-9e49-694c35b52455",
+          "tag": "246",
+          "label": "Test Statement",
+          "url": "https://www.loc.gov/marc/bibliographic/bd246.html",
+          "repeatable": false,
+          "required": true,
+          "deprecated": false,
+          "scope": "system",
+          "subfields": [
+            {
+              "id": "b6e694d2-c145-4e6a-80bf-d94c20438e8d",
+              "code": "6",
+              "label": "Linkage",
+              "repeatable": false,
+              "required": false,
+              "deprecated": false,
+              "scope": "standard"
+            }
+          ],
+          "indicators": [
+            {
+              "id": "8feb7051-ef5f-48fb-885b-f3d549c43c82",
+              "order": 1,
+              "label": "Title added entry",
+              "codes": [
+                {
+                  "id": "d91557e8-801b-441e-b90f-898e2bf305bc",
+                  "code": "0",
+                  "label": "No added entry",
+                  "deprecated": false,
+                  "scope": "standard"
+                }
+              ]
+            },
+            {
+              "id": "5e1017cf-497c-433b-b988-f9e927349f7a",
+              "order": 2,
+              "label": "Nonfiling characters",
+              "codes": [
+                {
+                  "id": "227736f6-c8c5-484e-aa1a-3abe2f293c93",
+                  "code": "0",
+                  "label": "Number of nonfiling characters",
+                  "deprecated": false,
+                  "scope": "standard"
+                }
+              ]
+            }
+          ]
         }
       ],
       "rules": [
@@ -281,6 +332,13 @@
           "name": "Non-Repeatable Field",
           "description": "Field is non-repeatable but exists more than once in a record",
           "code": "nonRepeatableField",
+          "enabled": true
+        },
+        {
+          "id": "c1b80d56-5f6f-4c0e-92df-6d2356eb379e",
+          "name": "Missing field",
+          "description": "Field is required but missing in a record",
+          "code": "missingField",
           "enabled": true
         }
       ]

--- a/src/test/resources/mockdata/response/specifications/specificationById.json
+++ b/src/test/resources/mockdata/response/specifications/specificationById.json
@@ -281,6 +281,57 @@
           ]
         }
       ]
+    },
+    {
+      "id": "f2b7ad73-8e82-4909-9e49-694c35b52455",
+      "tag": "246",
+      "label": "Test Statement",
+      "url": "https://www.loc.gov/marc/bibliographic/bd246.html",
+      "repeatable": false,
+      "required": true,
+      "deprecated": false,
+      "scope": "system",
+      "subfields": [
+        {
+          "id": "b6e694d2-c145-4e6a-80bf-d94c20438e8d",
+          "code": "6",
+          "label": "Linkage",
+          "repeatable": false,
+          "required": false,
+          "deprecated": false,
+          "scope": "standard"
+        }
+      ],
+      "indicators": [
+        {
+          "id": "8feb7051-ef5f-48fb-885b-f3d549c43c82",
+          "order": 1,
+          "label": "Title added entry",
+          "codes": [
+            {
+              "id": "d91557e8-801b-441e-b90f-898e2bf305bc",
+              "code": "0",
+              "label": "No added entry",
+              "deprecated": false,
+              "scope": "standard"
+            }
+          ]
+        },
+        {
+          "id": "5e1017cf-497c-433b-b988-f9e927349f7a",
+          "order": 2,
+          "label": "Nonfiling characters",
+          "codes": [
+            {
+              "id": "227736f6-c8c5-484e-aa1a-3abe2f293c93",
+              "code": "0",
+              "label": "Number of nonfiling characters",
+              "deprecated": false,
+              "scope": "standard"
+            }
+          ]
+        }
+      ]
     }
   ],
   "rules": [


### PR DESCRIPTION
### Purpose
Don't throw an exception on empty field content during record conversion

### Approach
Add soft conversion move for converting user record to quick MARC record so invalid content could be validated using record specification

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODQM-438](https://folio-org.atlassian.net/browse/MODQM-438)

### Screenshots
Verified on Rancher
![image](https://github.com/user-attachments/assets/e0fc28aa-e434-4d57-9618-895d73c3ff87)

