### PR TITLE
Update quick marc converter to convert indicator's empty spaces

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 ### Features
 * Implement endpoint to validate record based on MARC specification ([MODQM-433](https://issues.folio.org/browse/MODQM-433))
 * Update cached specification on kafka event ([MODQM-436](https://issues.folio.org/browse/MODQM-436))
+* Update QM to MarcRecord converter ([MODQM-443](https://issues.folio.org/browse/MODQM-443))
 
 ### Bug fixes
 * Add Microfiche support to Form position for music and score document type ([MODQM-419](https://folio-org.atlassian.net/browse/MODQM-419))

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
 ### Features
 * Implement endpoint to validate record based on MARC specification ([MODQM-433](https://issues.folio.org/browse/MODQM-433))
 * Update cached specification on kafka event ([MODQM-436](https://issues.folio.org/browse/MODQM-436))
-* Update QM to MarcRecord converter ([MODQM-443](https://issues.folio.org/browse/MODQM-443))
+* Update QM to MarcRecord converter to replace empty spaces to '#' in indicators ([MODQM-443](https://issues.folio.org/browse/MODQM-443))
 
 ### Bug fixes
 * Add Microfiche support to Form position for music and score document type ([MODQM-419](https://folio-org.atlassian.net/browse/MODQM-419))

--- a/src/main/java/org/folio/qm/converter/MarcQmToMarcRecordConverter.java
+++ b/src/main/java/org/folio/qm/converter/MarcQmToMarcRecordConverter.java
@@ -27,6 +27,9 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class MarcQmToMarcRecordConverter implements Converter<BaseMarcRecord, MarcRecord> {
 
+  private static final char EMPTY_SPACE_VALUE = 32;
+  private static final char MARC_INDICATOR_EMPTY_VALUE = '#';
+
   @Qualifier("marcFieldsSoftConverter")
   private final MarcFieldsConverter fieldsConverter;
 
@@ -84,7 +87,8 @@ public class MarcQmToMarcRecordConverter implements Converter<BaseMarcRecord, Ma
 
   private MarcIndicator toMarcIndicator(Reference fieldReference, char indicatorValue, int indicatorIndex) {
     var reference = Reference.forIndicator(fieldReference, indicatorIndex);
-    return new MarcIndicator(reference, indicatorValue);
+    var value = indicatorValue == EMPTY_SPACE_VALUE ? MARC_INDICATOR_EMPTY_VALUE : indicatorValue;
+    return new MarcIndicator(reference, value);
   }
 
   private MarcSubfield toMarcSubfield(Reference parentReference, List<Subfield> subfieldList, Subfield subfield) {

--- a/src/main/java/org/folio/qm/converter/MarcQmToMarcRecordConverter.java
+++ b/src/main/java/org/folio/qm/converter/MarcQmToMarcRecordConverter.java
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class MarcQmToMarcRecordConverter implements Converter<BaseMarcRecord, MarcRecord> {
 
-  private static final char EMPTY_SPACE_VALUE = 32;
+  private static final char EMPTY_SPACE_VALUE = ' ';
   private static final char MARC_INDICATOR_EMPTY_VALUE = '#';
 
   @Qualifier("marcFieldsSoftConverter")

--- a/src/test/java/org/folio/qm/converter/MarcQmToMarcRecordConverterTest.java
+++ b/src/test/java/org/folio/qm/converter/MarcQmToMarcRecordConverterTest.java
@@ -1,6 +1,7 @@
 package org.folio.qm.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -37,5 +38,21 @@ class MarcQmToMarcRecordConverterTest {
     assertThat(actual.dataFields()).hasSize(1);
     assertThat(actual.dataFields().get(0))
       .matches(field -> tag.equals(field.tag()) && field.subfields().isEmpty());
+  }
+
+  @Test
+  void convert_emptyFieldIndicatorContent() {
+    var source = new BaseMarcRecord().leader("test");
+    var tag = "245";
+
+    when(fieldsConverter.convertQmFields(any(), any())).thenReturn(List.of(new DataFieldImpl(tag, ' ', ' ')));
+
+    var actual = converter.convert(source);
+
+    assertThat(actual).isNotNull();
+    assertThat(actual.dataFields()).hasSize(1);
+    assertThat(actual.dataFields().get(0).indicators()).isNotNull();
+    assertThat(actual.dataFields().get(0).indicators()).hasSize(2);
+    actual.dataFields().get(0).indicators().forEach(ind -> assertEquals('#', ind.value()));
   }
 }


### PR DESCRIPTION
### Purpose
Convert empty spaces values to '#'

### Approach
Add replacement for empty spaces inside quick marc to marc record converter fro indicators

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODQM-443](https://issues.folio.org/browse/MODQM-443)
