### PR TITLE
feat(validation): Replace spaces with '\' instead of '#' in indicator codes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
 ### Features
 * Implement endpoint to validate record based on MARC specification ([MODQM-433](https://issues.folio.org/browse/MODQM-433))
 * Update cached specification on kafka event ([MODQM-436](https://issues.folio.org/browse/MODQM-436))
-* Update QM to MarcRecord converter to replace empty spaces to '\' in indicators ([MODQM-443](https://issues.folio.org/browse/MODQM-443))
+* Show '\' in indicators to user while internally using '#' value for validation ([MODQM-443](https://issues.folio.org/browse/MODQM-443))
 
 ### Bug fixes
 * Add Microfiche support to Form position for music and score document type ([MODQM-419](https://folio-org.atlassian.net/browse/MODQM-419))

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
 ### Features
 * Implement endpoint to validate record based on MARC specification ([MODQM-433](https://issues.folio.org/browse/MODQM-433))
 * Update cached specification on kafka event ([MODQM-436](https://issues.folio.org/browse/MODQM-436))
-* Update QM to MarcRecord converter to replace empty spaces to '#' in indicators ([MODQM-443](https://issues.folio.org/browse/MODQM-443))
+* Update QM to MarcRecord converter to replace empty spaces to '\' in indicators ([MODQM-443](https://issues.folio.org/browse/MODQM-443))
 
 ### Bug fixes
 * Add Microfiche support to Form position for music and score document type ([MODQM-419](https://folio-org.atlassian.net/browse/MODQM-419))

--- a/src/main/java/org/folio/qm/converter/MarcQmToMarcRecordConverter.java
+++ b/src/main/java/org/folio/qm/converter/MarcQmToMarcRecordConverter.java
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Component;
 public class MarcQmToMarcRecordConverter implements Converter<BaseMarcRecord, MarcRecord> {
 
   private static final char EMPTY_SPACE_VALUE = ' ';
-  private static final char MARC_INDICATOR_EMPTY_VALUE = '#';
+  private static final char MARC_INDICATOR_EMPTY_VALUE = '\\';
 
   @Qualifier("marcFieldsSoftConverter")
   private final MarcFieldsConverter fieldsConverter;

--- a/src/main/java/org/folio/qm/converter/MarcQmToMarcRecordConverter.java
+++ b/src/main/java/org/folio/qm/converter/MarcQmToMarcRecordConverter.java
@@ -28,7 +28,8 @@ import org.springframework.stereotype.Component;
 public class MarcQmToMarcRecordConverter implements Converter<BaseMarcRecord, MarcRecord> {
 
   private static final char EMPTY_SPACE_VALUE = ' ';
-  private static final char MARC_INDICATOR_EMPTY_VALUE = '\\';
+  private static final char QUICK_MARC_INDICATOR_EMPTY_VALUE = '\\';
+  private static final char VALIDATION_INDICATOR_EMPTY_VALUE = '#';
 
   @Qualifier("marcFieldsSoftConverter")
   private final MarcFieldsConverter fieldsConverter;
@@ -87,8 +88,16 @@ public class MarcQmToMarcRecordConverter implements Converter<BaseMarcRecord, Ma
 
   private MarcIndicator toMarcIndicator(Reference fieldReference, char indicatorValue, int indicatorIndex) {
     var reference = Reference.forIndicator(fieldReference, indicatorIndex);
-    var value = indicatorValue == EMPTY_SPACE_VALUE ? MARC_INDICATOR_EMPTY_VALUE : indicatorValue;
+    var value = indicatorValidatableValue(indicatorValue);
     return new MarcIndicator(reference, value);
+  }
+  
+  private char indicatorValidatableValue(char indicatorValue) {
+    return switch (indicatorValue) {
+      case EMPTY_SPACE_VALUE, QUICK_MARC_INDICATOR_EMPTY_VALUE -> VALIDATION_INDICATOR_EMPTY_VALUE;
+      case VALIDATION_INDICATOR_EMPTY_VALUE -> QUICK_MARC_INDICATOR_EMPTY_VALUE;
+      default -> indicatorValue;
+    };
   }
 
   private MarcSubfield toMarcSubfield(Reference parentReference, List<Subfield> subfieldList, Subfield subfield) {

--- a/src/main/java/org/folio/qm/service/impl/ValidationServiceImpl.java
+++ b/src/main/java/org/folio/qm/service/impl/ValidationServiceImpl.java
@@ -1,6 +1,7 @@
 package org.folio.qm.service.impl;
 
 import static org.folio.qm.util.ErrorUtils.buildError;
+import static org.folio.rspec.validation.validator.marc.model.MarcRuleCode.INVALID_INDICATOR;
 
 import java.util.Collections;
 import java.util.List;
@@ -79,12 +80,20 @@ public class ValidationServiceImpl implements ValidationService {
     var helpUrl = SpecificationUtils.findField(specification, path.substring(0, path.indexOf('[')))
       .map(SpecificationFieldDto::getUrl)
       .orElse(null);
+    var message = getValidationIssueMessage(validationError);
     return new ValidationIssue()
       .tag(path.substring(0, path.indexOf(']') + 1))
       .helpUrl(helpUrl)
       .severity(validationError.getSeverity().getType())
       .definitionType(validationError.getDefinitionType().getType())
-      .message(validationError.getMessage());
+      .message(message);
+  }
+
+  private String getValidationIssueMessage(ValidationError validationError) {
+    var originalMessage = validationError.getMessage();
+    return INVALID_INDICATOR.getCode().equals(validationError.getRuleCode())
+      ? originalMessage.replace('#', '\\')
+      : originalMessage;
   }
 
 }

--- a/src/test/java/org/folio/qm/converter/MarcQmToMarcRecordConverterTest.java
+++ b/src/test/java/org/folio/qm/converter/MarcQmToMarcRecordConverterTest.java
@@ -45,7 +45,23 @@ class MarcQmToMarcRecordConverterTest {
     var source = new BaseMarcRecord().leader("test");
     var tag = "245";
 
-    when(fieldsConverter.convertQmFields(any(), any())).thenReturn(List.of(new DataFieldImpl(tag, ' ', ' ')));
+    when(fieldsConverter.convertQmFields(any(), any())).thenReturn(List.of(new DataFieldImpl(tag, ' ', '\\')));
+
+    var actual = converter.convert(source);
+
+    assertThat(actual).isNotNull();
+    assertThat(actual.dataFields()).hasSize(1);
+    assertThat(actual.dataFields().get(0).indicators()).isNotNull();
+    assertThat(actual.dataFields().get(0).indicators()).hasSize(2);
+    actual.dataFields().get(0).indicators().forEach(ind -> assertEquals('#', ind.value()));
+  }
+
+  @Test
+  void convert_invalidFieldIndicatorContent() {
+    var source = new BaseMarcRecord().leader("test");
+    var tag = "245";
+
+    when(fieldsConverter.convertQmFields(any(), any())).thenReturn(List.of(new DataFieldImpl(tag, '#', '#')));
 
     var actual = converter.convert(source);
 

--- a/src/test/java/org/folio/qm/converter/MarcQmToMarcRecordConverterTest.java
+++ b/src/test/java/org/folio/qm/converter/MarcQmToMarcRecordConverterTest.java
@@ -53,6 +53,6 @@ class MarcQmToMarcRecordConverterTest {
     assertThat(actual.dataFields()).hasSize(1);
     assertThat(actual.dataFields().get(0).indicators()).isNotNull();
     assertThat(actual.dataFields().get(0).indicators()).hasSize(2);
-    actual.dataFields().get(0).indicators().forEach(ind -> assertEquals('#', ind.value()));
+    actual.dataFields().get(0).indicators().forEach(ind -> assertEquals('\\', ind.value()));
   }
 }

--- a/src/test/java/org/folio/qm/service/impl/ValidationServiceImplTest.java
+++ b/src/test/java/org/folio/qm/service/impl/ValidationServiceImplTest.java
@@ -1,0 +1,52 @@
+package org.folio.qm.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.rspec.validation.validator.marc.model.MarcRuleCode.INVALID_INDICATOR;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.folio.qm.domain.dto.ValidatableRecord;
+import org.folio.qm.service.MarcSpecificationService;
+import org.folio.qm.validation.ValidationRule;
+import org.folio.rspec.domain.dto.DefinitionType;
+import org.folio.rspec.domain.dto.SeverityType;
+import org.folio.rspec.domain.dto.SpecificationDto;
+import org.folio.rspec.domain.dto.ValidationError;
+import org.folio.rspec.validation.SpecificationGuidedValidator;
+import org.folio.spring.testing.type.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class ValidationServiceImplTest {
+
+  private @Mock List<ValidationRule> validationRules;
+  private @Mock MarcSpecificationService marcSpecificationService;
+  private @Mock SpecificationGuidedValidator validatableRecordValidator;
+
+  private @InjectMocks ValidationServiceImpl service;
+
+  @Test
+  void validate_shouldModifyIndicatorErrorMessage() {
+    var error = ValidationError.builder()
+      .path("path[0]")
+      .severity(SeverityType.ERROR)
+      .definitionType(DefinitionType.INDICATOR)
+      .ruleCode(INVALID_INDICATOR.getCode())
+      .message("Indicator must contain one character and can only accept numbers 0-9, letters a-z or a '#'.")
+      .build();
+    when(validatableRecordValidator.validate(any(), any())).thenReturn(List.of(error));
+    when(marcSpecificationService.getSpecification(any())).thenReturn(new SpecificationDto());
+
+    var result = service.validate(new ValidatableRecord());
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getMessage())
+      .isEqualTo("Indicator must contain one character and can only accept numbers 0-9, letters a-z or a '\\'.");
+  }
+}


### PR DESCRIPTION
### Purpose
Use '#' for indicators validation internally while using ' ' or '\\' on UI side

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODQM-443](https://folio-org.atlassian.net/browse/MODQM-443)
