### PR TITLE
fix(subfield-converter) exclude empty subfields from subfields converter.

### DIFF
--- a/src/main/java/org/folio/qm/converter/MarcQmToMarcRecordConverter.java
+++ b/src/main/java/org/folio/qm/converter/MarcQmToMarcRecordConverter.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.qm.domain.dto.BaseMarcRecord;
 import org.folio.rspec.validation.validator.marc.model.MarcControlField;
 import org.folio.rspec.validation.validator.marc.model.MarcDataField;
@@ -74,6 +75,7 @@ public class MarcQmToMarcRecordConverter implements Converter<BaseMarcRecord, Ma
   private List<MarcSubfield> convertSubfields(Reference parentReference, List<Subfield> subfields) {
     var marcSubfields = new ArrayList<MarcSubfield>();
     subfields.stream()
+      .filter(subfield -> StringUtils.isNotBlank(subfield.getData()))
       .collect(Collectors.groupingBy(Subfield::getCode))
       .forEach((code, subfieldList) -> subfieldList.forEach(subfield ->
         marcSubfields.add(toMarcSubfield(parentReference, subfieldList, subfield))));
@@ -91,7 +93,7 @@ public class MarcQmToMarcRecordConverter implements Converter<BaseMarcRecord, Ma
     var value = indicatorValidatableValue(indicatorValue);
     return new MarcIndicator(reference, value);
   }
-  
+
   private char indicatorValidatableValue(char indicatorValue) {
     return switch (indicatorValue) {
       case EMPTY_SPACE_VALUE, QUICK_MARC_INDICATOR_EMPTY_VALUE -> VALIDATION_INDICATOR_EMPTY_VALUE;

--- a/src/test/java/org/folio/qm/support/utils/testentities/TestEntitiesUtils.java
+++ b/src/test/java/org/folio/qm/support/utils/testentities/TestEntitiesUtils.java
@@ -21,6 +21,7 @@ public class TestEntitiesUtils {
   public static final String QM_RECORD_EDIT_BIB_PATH = PARSED_RECORDS_DIR + "/quickMarcBibEdit.json";
   public static final String QM_RECORD_CREATE_BIB_PATH = PARSED_RECORDS_DIR + "/quickMarcBibCreate.json";
   public static final String QM_RECORD_VALIDATE_PATH = PARSED_RECORDS_DIR + "/quickMarcValidate.json";
+  public static final String QM_RECORD_VALIDATE_SUBFIELD_PATH = PARSED_RECORDS_DIR + "/quickMarcSubfieldValidate.json";
   public static final String QM_RECORD_VIEW_BIB_PATH = PARSED_RECORDS_DIR + "/quickMarcBibView.json";
   public static final String QM_RECORD_EDIT_HOLDINGS_PATH = PARSED_RECORDS_DIR + "/quickMarcHoldingsEdit.json";
   public static final String QM_RECORD_CREATE_HOLDINGS_PATH = PARSED_RECORDS_DIR + "/quickMarcHoldingsCreate.json";

--- a/src/test/resources/mockdata/response/quickMarcSubfieldValidate.json
+++ b/src/test/resources/mockdata/response/quickMarcSubfieldValidate.json
@@ -1,0 +1,70 @@
+{
+  "marcFormat": "BIBLIOGRAPHIC",
+  "leader": "01706ccm\\a2200361\\\\ 4500",
+  "fields": [
+    {
+      "tag": "001",
+      "content": "393893"
+    },
+    {
+      "tag": "005",
+      "content": "20141107001016.0"
+    },
+    {
+      "tag": "010",
+      "content": "$a   2001000234",
+      "indicators": [
+        " ",
+        "\\"
+      ]
+    },
+    {
+      "tag": "1000",
+      "content": "$a Mozart, Wolfgang Amadeus, $d 1756-1791.",
+      "indicators": [
+        "1",
+        "\\"
+      ]
+    },
+    {
+      "tag": "245",
+      "content": "$a Neue Ausgabe samtlicher Werke $6 non-repeatable field $6 non-repeatable field",
+      "indicators": [
+        "1",
+        "0"
+      ]
+    },
+    {
+      "tag": "245",
+      "content": "$a Neue Ausgabe samtlicher Werke additional $7 repeatable field $7 repeatable field $s non-repeatable field $s $s",
+      "indicators": [
+        "2",
+        "0"
+      ]
+    },
+    {
+      "tag": "245",
+      "content": "$a non-repeatable field $a non-repeatable field $s $s  ",
+      "indicators": [
+        "2",
+        "0"
+      ]
+    },
+    {
+      "tag": "246",
+      "content": "$6  $6 $6 non-repeatable field",
+      "indicators": [
+        "2",
+        "0"
+      ]
+    },
+    {
+      "tag": "998",
+      "content": "$a Works",
+      "indicators": [
+        "1",
+        "0"
+      ]
+    }
+  ]
+}

--- a/src/test/resources/mockdata/response/specifications/specification.json
+++ b/src/test/resources/mockdata/response/specifications/specification.json
@@ -340,6 +340,12 @@
           "description": "Field is required but missing in a record",
           "code": "missingField",
           "enabled": true
+        }, {
+          "id": "1aa070fd-d2b5-4def-bf3d-699895f13b88",
+          "name": "Non-Repeatable Subfield",
+          "description": "Subfield is non-repeatable but exists more than once in a record's field",
+          "code": "nonRepeatableSubfield",
+          "enabled": true
         }
       ]
     }


### PR DESCRIPTION
### Purpose
[MRSPECS-48](https://folio-org.atlassian.net/browse/MRSPECS-48) Exclude empty subfields from subfields converter as this affects the validation result in the mod-record-specifications.

### Approach
Exclude empty subfields from subfields converter as this affects the validation result in the mod-record-specifications.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.
