### PR TITLE
fix(validation): return '\' instead '#' in validation message for undefined indicator rule

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,8 @@
 ### Features
 * Implement endpoint to validate record based on MARC specification ([MODQM-433](https://issues.folio.org/browse/MODQM-433))
 * Update cached specification on kafka event ([MODQM-436](https://issues.folio.org/browse/MODQM-436))
-* Show '\' in indicators to user while internally using '#' value for validation ([MODQM-443](https://issues.folio.org/browse/MODQM-443))
+* Return '\' instead '#' in validation message for invalid indicator rule ([MODQM-443](https://issues.folio.org/browse/MODQM-443))
+* Return '\' instead '#' in validation message for undefined indicator rule ([MODQM-448](https://issues.folio.org/browse/MODQM-448))
 * Create and update endpoints modified to validate MARC record based on MARC specification ([MODQM-434](https://folio-org.atlassian.net/browse/MODQM-434))
 
 ### Bug fixes

--- a/src/main/java/org/folio/qm/service/impl/ValidationServiceImpl.java
+++ b/src/main/java/org/folio/qm/service/impl/ValidationServiceImpl.java
@@ -2,6 +2,7 @@ package org.folio.qm.service.impl;
 
 import static org.folio.qm.util.ErrorUtils.buildError;
 import static org.folio.rspec.validation.validator.marc.model.MarcRuleCode.INVALID_INDICATOR;
+import static org.folio.rspec.validation.validator.marc.model.MarcRuleCode.UNDEFINED_INDICATOR;
 
 import java.util.Collections;
 import java.util.List;
@@ -116,7 +117,8 @@ public class ValidationServiceImpl implements ValidationService {
 
   private String getValidationIssueMessage(ValidationError validationError) {
     var originalMessage = validationError.getMessage();
-    return INVALID_INDICATOR.getCode().equals(validationError.getRuleCode())
+    var ruleCode = validationError.getRuleCode();
+    return INVALID_INDICATOR.getCode().equals(ruleCode) || UNDEFINED_INDICATOR.getCode().equals(ruleCode)
       ? originalMessage.replace('#', '\\')
       : originalMessage;
   }

--- a/src/test/java/org/folio/qm/service/impl/ValidationServiceImplTest.java
+++ b/src/test/java/org/folio/qm/service/impl/ValidationServiceImplTest.java
@@ -1,22 +1,22 @@
 package org.folio.qm.service.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.folio.rspec.validation.validator.marc.model.MarcRuleCode.INVALID_INDICATOR;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import org.folio.qm.domain.dto.ValidatableRecord;
 import org.folio.qm.service.MarcSpecificationService;
-import org.folio.qm.validation.ValidationRule;
 import org.folio.rspec.domain.dto.DefinitionType;
 import org.folio.rspec.domain.dto.SeverityType;
 import org.folio.rspec.domain.dto.SpecificationDto;
 import org.folio.rspec.domain.dto.ValidationError;
 import org.folio.rspec.validation.SpecificationGuidedValidator;
+import org.folio.rspec.validation.validator.marc.model.MarcRuleCode;
 import org.folio.spring.testing.type.UnitTest;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -25,20 +25,22 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class ValidationServiceImplTest {
 
-  private @Mock List<ValidationRule> validationRules;
   private @Mock MarcSpecificationService marcSpecificationService;
   private @Mock SpecificationGuidedValidator validatableRecordValidator;
 
   private @InjectMocks ValidationServiceImpl service;
 
-  @Test
-  void validate_shouldModifyIndicatorErrorMessage() {
+  @EnumSource(value = MarcRuleCode.class,
+              mode = EnumSource.Mode.INCLUDE,
+              names = {"INVALID_INDICATOR", "UNDEFINED_INDICATOR"})
+  @ParameterizedTest
+  void validate_shouldModifyIndicatorErrorMessage(MarcRuleCode marcRuleCode) {
     var error = ValidationError.builder()
       .path("path[0]")
       .severity(SeverityType.ERROR)
       .definitionType(DefinitionType.INDICATOR)
-      .ruleCode(INVALID_INDICATOR.getCode())
-      .message("Indicator must contain one character and can only accept numbers 0-9, letters a-z or a '#'.")
+      .ruleCode(marcRuleCode.getCode())
+      .message("Message that contains '#'.")
       .build();
     when(validatableRecordValidator.validate(any(), any())).thenReturn(List.of(error));
     when(marcSpecificationService.getSpecification(any())).thenReturn(new SpecificationDto());
@@ -47,6 +49,6 @@ class ValidationServiceImplTest {
 
     assertThat(result).hasSize(1);
     assertThat(result.get(0).getMessage())
-      .isEqualTo("Indicator must contain one character and can only accept numbers 0-9, letters a-z or a '\\'.");
+      .isEqualTo("Message that contains '\\'.");
   }
 }


### PR DESCRIPTION
### Purpose
Return '\' instead '#' in validation message for undefined indicator rule

### Approach
Modify message for specific code

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MODQM-448

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/a6aad8a3-33c4-4b70-8aa2-e42ad14e2557)

