### PR TITLE
chore (interface deps): MODQM-475 - Change dependencies on SRM and converter-storage interfaces to optional

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -3,24 +3,8 @@
   "name": "quickMARC",
   "requires": [
     {
-      "id": "source-manager-parsed-records",
-      "version": "3.0"
-    },
-    {
-      "id": "source-manager-job-executions",
-      "version": "3.4"
-    },
-    {
-      "id": "source-manager-records",
-      "version": "2.0"
-    },
-    {
       "id": "users",
       "version": "15.0 16.0"
-    },
-    {
-      "id": "field-protection-settings",
-      "version": "1.2"
     },
     {
       "id": "instance-authority-links",
@@ -37,6 +21,24 @@
     {
       "id": "specification-storage",
       "version": "1.0"
+    }
+  ],
+  "optional": [
+    {
+      "id": "source-manager-parsed-records",
+      "version": "3.0"
+    },
+    {
+      "id": "source-manager-job-executions",
+      "version": "3.4"
+    },
+    {
+      "id": "source-manager-records",
+      "version": "2.0"
+    },
+    {
+      "id": "field-protection-settings",
+      "version": "1.2"
     }
   ],
   "provides": [


### PR DESCRIPTION
## Purpose
To accomplish the migration of the mod-source-record-manager and mod-di-converter modules from app-platform-complete to app-data-import application, it is necessary to temporarily change dependencies on these interfaces to optional until mod-quick-marc module is moved to its own separate application:
- "source-manager-parsed-records"
- "source-manager-job-executions"
- "source-manager-records"
- "field-protection-settings"




## Learning
[MODQM-475](https://issues.folio.org/browse/MODQM-475)