### PR TITLE
feat(create-record):  use MarcRecordNormalizer from data-import-processing-core for MARC OCLC 035 value normalization.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@
 * Implement MARC Record Create Flow ([MODQM-491](https://folio-org.atlassian.net/browse/MODQM-491))
 * Handle 003 and 035 fields in MARC Record Create flow ([MODQM-497](https://folio-org.atlassian.net/browse/MODQM-497))
 * Use Setting API to determine extended authority mapping ([MODQM-501](https://folio-org.atlassian.net/browse/MODQM-501))
+* Use MarcRecordNormalizer from data-import-processing-core for MARC OCLC 035 value normalization ([MODQM-498](https://folio-org.atlassian.net/browse/MODQM-498))
 
 ### Bug fixes
 * Set staffSuppress, discoverySuppress and suppressDiscovery to true when LDR/05 is 'd' on create or update ([MODQM-509](https://folio-org.atlassian.net/browse/MODQM-509))

--- a/src/main/java/org/folio/qm/service/change/InstanceChangeRecordService.java
+++ b/src/main/java/org/folio/qm/service/change/InstanceChangeRecordService.java
@@ -2,6 +2,7 @@ package org.folio.qm.service.change;
 
 import lombok.extern.log4j.Log4j2;
 import org.folio.ExternalIdsHolder;
+import org.folio.processing.util.MarcRecordNormalizer;
 import org.folio.qm.convertion.RecordConversionService;
 import org.folio.qm.domain.dto.MarcFormat;
 import org.folio.qm.domain.model.InstanceFolioRecord;
@@ -45,7 +46,7 @@ public class InstanceChangeRecordService extends AbstractChangeRecordService<Ins
     var marcRecord = qmRecord.getMarcRecord();
     MarcRecordModifier.remove003Field(marcRecord);
     log.debug("updateNonRequiredFields:: normalizing 035 fields in the instance marc record if exists");
-    MarcRecordModifier.normalize035Field(marcRecord);
+    MarcRecordNormalizer.normalize035Field(marcRecord);
     qmRecord.buildParsedContent();
   }
 

--- a/src/main/java/org/folio/qm/util/MarcRecordModifier.java
+++ b/src/main/java/org/folio/qm/util/MarcRecordModifier.java
@@ -4,9 +4,6 @@ import io.vertx.core.json.JsonObject;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Pattern;
 import lombok.extern.log4j.Log4j2;
 import org.marc4j.MarcJsonReader;
 import org.marc4j.MarcJsonWriter;
@@ -14,7 +11,6 @@ import org.marc4j.MarcStreamWriter;
 import org.marc4j.marc.DataField;
 import org.marc4j.marc.MarcFactory;
 import org.marc4j.marc.Record;
-import org.marc4j.marc.Subfield;
 import org.marc4j.marc.VariableField;
 
 /**
@@ -28,16 +24,8 @@ public final class MarcRecordModifier {
   public static final String TAG_001 = "001";
   public static final String TAG_003 = "003";
   public static final String TAG_004 = "004";
-  public static final String TAG_035 = "035";
   public static final char INDICATOR_F = 'f';
   public static final char SUBFIELD_I = 'i';
-  private static final String OCLC_PREFIX = "(OCoLC)";
-  private static final String OCLC = "OCoLC";
-  private static final String OCLC_PATTERN = "\\((" + OCLC + ")\\)((ocm|ocn|on)?0*|([a-zA-Z]+)0*)(\\d+\\w*)";
-  private static final Pattern OCLC_COMPILED = Pattern.compile(OCLC_PATTERN);
-  private static final Pattern DOT_OR_WHITESPACE_PATTERN = Pattern.compile("[.\\s]");
-  private static final Pattern DIGITS_PATTERN = Pattern.compile("\\d+");
-  private static final Pattern PREFIX_ZEROS_PATTERN = Pattern.compile("^0+");
 
   private static final MarcFactory FACTORY = MarcFactory.newInstance();
 
@@ -105,23 +93,6 @@ public final class MarcRecordModifier {
    */
   public static void remove003Field(Record marcRecord) {
     marcRecord.getVariableFields(TAG_003).forEach(marcRecord::removeVariableField);
-  }
-
-  /**
-   * Normalizes 035 fields containing OCLC numbers in the MARC record.
-   * Formats OCLC numbers and removes duplicates.
-   *
-   * @param marcRecord the marc4j Record to modify
-   */
-  public static void normalize035Field(Record marcRecord) {
-    if (marcRecord == null) {
-      return;
-    }
-    var subfields = get035SubfieldOclcValues(marcRecord);
-    if (!subfields.isEmpty()) {
-      formatOclc(subfields);
-      deduplicateOclc(marcRecord, subfields);
-    }
   }
 
   /**
@@ -201,75 +172,5 @@ public final class MarcRecordModifier {
       }
     }
     return null;
-  }
-
-  private static List<Subfield> get035SubfieldOclcValues(Record marcRecord) {
-    List<Subfield> subfields = new ArrayList<>();
-    for (VariableField field : marcRecord.getVariableFields(TAG_035)) {
-      if (field instanceof DataField dataField) {
-        for (Subfield sf : dataField.getSubfields()) {
-          if (sf.getData() != null && sf.getData().trim().startsWith(OCLC_PREFIX)) {
-            subfields.add(sf);
-          }
-        }
-      }
-    }
-    return subfields;
-  }
-
-  private static void formatOclc(List<Subfield> subfields) {
-    for (Subfield subfield : subfields) {
-      var data = DOT_OR_WHITESPACE_PATTERN.matcher(subfield.getData()).replaceAll("");
-      var matcher = OCLC_COMPILED.matcher(data);
-      if (matcher.find()) {
-        var oclcTag = matcher.group(1); // "OCoLC"
-        var numericAndTrailing = matcher.group(5); // Numeric part and any characters that follow
-        var prefix = matcher.group(2); // Entire prefix including letters and potentially leading zeros
-
-        if (prefix != null && (prefix.startsWith("ocm") || prefix.startsWith("ocn") || prefix.startsWith("on"))) {
-          // If "ocm" or "ocn", strip entirely from the prefix
-          subfield.setData("(" + oclcTag + ")" + numericAndTrailing);
-        } else {
-          // For other cases, strip leading zeros only from the numeric part
-          numericAndTrailing = PREFIX_ZEROS_PATTERN.matcher(numericAndTrailing).replaceFirst("");
-          if (prefix != null) {
-            prefix = DIGITS_PATTERN.matcher(prefix).replaceAll(""); // Safely remove digits from the prefix if not null
-          }
-          // Add back any other prefix that might have been included like "tfe"
-          subfield.setData("(" + oclcTag + ")" + (prefix != null ? prefix : "") + numericAndTrailing);
-        }
-      }
-    }
-  }
-
-  private static void deduplicateOclc(Record marcRecord, List<Subfield> subfields) {
-    List<Subfield> subfieldsToDelete = new ArrayList<>();
-
-    for (Subfield subfield : new ArrayList<>(subfields)) {
-      if (subfields.stream().anyMatch(s -> isOclcSubfieldDuplicated(subfield, s))) {
-        subfieldsToDelete.add(subfield);
-        subfields.remove(subfield);
-      }
-    }
-    var variableFields = marcRecord.getVariableFields(TAG_035);
-    subfieldsToDelete.forEach(subfieldToDelete ->
-      variableFields.forEach(field -> removeSubfieldIfExist(marcRecord, field, subfieldToDelete)));
-  }
-
-  private static boolean isOclcSubfieldDuplicated(Subfield s1, Subfield s2) {
-    return !s1.equals(s2)
-      && s1.getData().equals(s2.getData())
-      && s1.getCode() == s2.getCode();
-  }
-
-  private static void removeSubfieldIfExist(Record marcRecord, VariableField field,
-                                            Subfield subfieldToDelete) {
-    if (field instanceof DataField dataField && dataField.getSubfields().contains(subfieldToDelete)) {
-      if (dataField.getSubfields().size() > 1) {
-        dataField.removeSubfield(subfieldToDelete);
-      } else {
-        marcRecord.removeVariableField(dataField);
-      }
-    }
   }
 }

--- a/src/test/java/org/folio/qm/util/MarcRecordModifierTest.java
+++ b/src/test/java/org/folio/qm/util/MarcRecordModifierTest.java
@@ -8,12 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.stream.Stream;
 import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.marc4j.marc.DataField;
 import org.marc4j.marc.MarcFactory;
 import org.marc4j.marc.Record;
@@ -122,94 +118,6 @@ class MarcRecordModifierTest {
     assertNotNull(exception);
   }
 
-  @ParameterizedTest
-  @MethodSource("oclcNormalizationArguments")
-  void shouldNormalize035Field(String given, String expected) {
-    var basicRecord = createBasicRecord();
-    var field = FACTORY.newDataField("035", ' ', ' ');
-    field.addSubfield(FACTORY.newSubfield('a', given));
-    basicRecord.addVariableField(field);
-
-    MarcRecordModifier.normalize035Field(basicRecord);
-
-    var updatedField = (DataField) basicRecord.getVariableField("035");
-    assertEquals(expected, updatedField.getSubfield('a').getData());
-  }
-
-  @Test
-  void shouldDeduplicate035Field() {
-    var basicRecord = createBasicRecord();
-    var field1 = FACTORY.newDataField("035", ' ', ' ');
-    field1.addSubfield(FACTORY.newSubfield('a', "(OCoLC)12345"));
-    basicRecord.addVariableField(field1);
-
-    var field2 = FACTORY.newDataField("035", ' ', ' ');
-    field2.addSubfield(FACTORY.newSubfield('a', "(OCoLC)12345"));
-    basicRecord.addVariableField(field2);
-
-    MarcRecordModifier.normalize035Field(basicRecord);
-
-    assertEquals(1, basicRecord.getVariableFields("035").size());
-  }
-
-  @Test
-  void shouldHandleMultipleSubfieldsIn035() {
-    var basicRecord = createBasicRecord();
-
-    var field1 = FACTORY.newDataField("035", ' ', ' ');
-    field1.addSubfield(FACTORY.newSubfield('a', "(OCoLC)64758"));
-    basicRecord.addVariableField(field1);
-
-    var field2 = FACTORY.newDataField("035", ' ', ' ');
-    field2.addSubfield(FACTORY.newSubfield('a', "(OCoLC)ocm000064758"));
-    field2.addSubfield(FACTORY.newSubfield('k', "(OCoLC)976939443"));
-    field2.addSubfield(FACTORY.newSubfield('k', "(OCoLC)1001261435"));
-    field2.addSubfield(FACTORY.newSubfield('k', "(OCoLC)120194933"));
-    basicRecord.addVariableField(field2);
-
-    MarcRecordModifier.normalize035Field(basicRecord);
-
-    var updatedField = (DataField) basicRecord.getVariableField("035");
-    assertNotNull(updatedField);
-    assertEquals(4, updatedField.getSubfields().size());
-    assertEquals("(OCoLC)64758", updatedField.getSubfield('a').getData());
-    var subfieldsK = updatedField.getSubfields('k');
-    assertEquals(3, subfieldsK.size());
-    assertEquals("(OCoLC)976939443", subfieldsK.get(0).getData());
-    assertEquals("(OCoLC)1001261435", subfieldsK.get(1).getData());
-    assertEquals("(OCoLC)120194933", subfieldsK.get(2).getData());
-  }
-
-  @Test
-  void shouldNotNormalize035FieldWhenNoOclc() {
-    var basicRecord = createBasicRecord();
-    var field = FACTORY.newDataField("035", ' ', ' ');
-    var originalValue = "other-prefix-12345";
-    field.addSubfield(FACTORY.newSubfield('a', originalValue));
-    basicRecord.addVariableField(field);
-
-    MarcRecordModifier.normalize035Field(basicRecord);
-
-    var updatedField = (DataField) basicRecord.getVariableField("035");
-    assertEquals(originalValue, updatedField.getSubfield('a').getData());
-  }
-
-  @Test
-  void shouldNotRemoveNonDuplicate035Fields() {
-    var basicRecord = createBasicRecord();
-    var field1 = FACTORY.newDataField("035", ' ', ' ');
-    field1.addSubfield(FACTORY.newSubfield('a', "(OCoLC)12345"));
-    basicRecord.addVariableField(field1);
-
-    var field2 = FACTORY.newDataField("035", ' ', ' ');
-    field2.addSubfield(FACTORY.newSubfield('a', "(OCoLC)67890"));
-    basicRecord.addVariableField(field2);
-
-    MarcRecordModifier.normalize035Field(basicRecord);
-
-    assertEquals(2, basicRecord.getVariableFields("035").size());
-  }
-
   @Test
   void shouldRemove003Field() {
     var basicRecord = createBasicRecord();
@@ -234,16 +142,6 @@ class MarcRecordModifierTest {
     basicRecord.addVariableField(FACTORY.newControlField("004", "instanceHrid"));
     var result = MarcRecordModifier.get004ControlFieldData(basicRecord);
     assertEquals("instanceHrid", result);
-  }
-
-  private static Stream<Arguments> oclcNormalizationArguments() {
-    return Stream.of(
-      Arguments.of("(OCoLC)tfe0000501056183", "(OCoLC)tfe501056183"),
-      Arguments.of("(OCoLC)0000501056183", "(OCoLC)501056183"),
-      Arguments.of("(OCoLC)501056183", "(OCoLC)501056183"),
-      Arguments.of("(OCoLC)ocm0000123456", "(OCoLC)123456"),
-      Arguments.of("(OCoLC)ocm000064758", "(OCoLC)64758")
-    );
   }
 
   private Record createBasicRecord() {


### PR DESCRIPTION
### Purpose
The logic for normalizing OCLC values in the MARC 035 field is being centralized in the `data-import-processing-core` module to avoid duplication and ensure consistent behavior across modules.
Once the shared implementation is available, `mod-quick-marc` should stop using its local 035 normalization logic and instead rely on the implementation provided by `data-import-processing-core`.

### Approach
- use MarcRecordNormalizer from `data-import-processing-core` for MARC OCLC 035 value normalization.
- remove duplicated 035 normalization code

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODQM-498](https://folio-org.atlassian.net/browse/MODQM-498)

