### PR TITLE
fix(update-record): update Instance record merger to ignore `statusUpdatedDate` field during merge

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
 
 ### Bug fixes
-* Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
+* Ignore `statusUpdatedDate` Instance field that is not mapped from MARC ([MODQM-514](https://folio-org.atlassian.net/browse/MODQM-514))
 
 ### Tech Dept
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/src/main/java/org/folio/qm/convertion/merger/InstanceRecordMerger.java
+++ b/src/main/java/org/folio/qm/convertion/merger/InstanceRecordMerger.java
@@ -19,6 +19,7 @@ public interface InstanceRecordMerger extends FolioRecordMerger<InstanceFolioRec
   @Mapping(target = "natureOfContentTermIds", ignore = true)
   @Mapping(target = "previouslyHeld", ignore = true)
   @Mapping(target = "statusId", ignore = true)
+  @Mapping(target = "statusUpdatedDate", ignore = true)
   @Mapping(target = "catalogedDate", ignore = true)
   @Mapping(target = "tags", ignore = true)
   @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)

--- a/src/test/java/org/folio/qm/convertion/merger/InstanceRecordMergerTest.java
+++ b/src/test/java/org/folio/qm/convertion/merger/InstanceRecordMergerTest.java
@@ -23,6 +23,8 @@ class InstanceRecordMergerTest {
   private static final String SOURCE_NOTE = "source-note";
   private static final String TARGET_STATUS_ID = "target-status-id";
   private static final String SOURCE_STATUS_ID = "source-status-id";
+  private static final String TARGET_STATUS_UPDATED_DATE = "target-status-updated-date";
+  private static final String SOURCE_STATUS_UPDATED_DATE = "source-status-updated-date";
   private static final String TARGET_STATISTICAL_CODE_ID = "target-statistical-code-id";
   private static final String SOURCE_STATISTICAL_CODE_ID = "source-statistical-code-id";
   private static final String TARGET_NATURE_OF_CONTENT_ID = "target-nature-of-content-id";
@@ -56,6 +58,7 @@ class InstanceRecordMergerTest {
     source.setNatureOfContentTermIds(List.of(SOURCE_NATURE_OF_CONTENT_ID));
     source.setPreviouslyHeld(false);
     source.setStatusId(SOURCE_STATUS_ID);
+    source.setStatusUpdatedDate(SOURCE_STATUS_UPDATED_DATE);
     source.setAdministrativeNotes(List.of(SOURCE_NOTE));
     var target = createInstanceRecord();
     target.setStaffSuppress(true);
@@ -64,6 +67,7 @@ class InstanceRecordMergerTest {
     target.setNatureOfContentTermIds(new LinkedHashSet<>(Set.of(TARGET_NATURE_OF_CONTENT_ID)));
     target.setPreviouslyHeld(true);
     target.setStatusId(TARGET_STATUS_ID);
+    target.setStatusUpdatedDate(TARGET_STATUS_UPDATED_DATE);
     target.setAdministrativeNotes(List.of(TARGET_NOTE));
 
     // Act
@@ -77,6 +81,7 @@ class InstanceRecordMergerTest {
     assertThat(target.getNatureOfContentTermIds()).containsExactly(TARGET_NATURE_OF_CONTENT_ID);
     assertThat(target.getPreviouslyHeld()).isTrue();
     assertThat(target.getStatusId()).isEqualTo(TARGET_STATUS_ID);
+    assertThat(target.getStatusUpdatedDate()).isEqualTo(TARGET_STATUS_UPDATED_DATE);
   }
 
   @Test


### PR DESCRIPTION
### Purpose
Following fields of Instance are cleared after MARC bibliographic record editing via quickmarc:
- `status updated`  - of `Instance status term` field

### Approach
- update Instance record merger to ignore `statusUpdatedDate` field during merge

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODQM-514](https://folio-org.atlassian.net/browse/MODQM-514)
