### PR TITLE
fix: do not include nullable `allowedValues` field in specification response

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 ### Bug fixes
 * Ignore `statusUpdatedDate` Instance field that is not mapped from MARC ([MODQM-514](https://folio-org.atlassian.net/browse/MODQM-514))
 * Fix MARC 008 fields shifting left when positions 00-05 contain blank characters ([MODQM-515](https://folio-org.atlassian.net/browse/MODQM-515))
+* Do not include nullable `allowedValues` field in specification response ([MODQM-519](https://folio-org.atlassian.net/browse/MODQM-519))
 
 ### Tech Dept
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/src/main/resources/swagger.api/schemas/marcSpecificationItem.yaml
+++ b/src/main/resources/swagger.api/schemas/marcSpecificationItem.yaml
@@ -31,6 +31,7 @@ properties:
     example: true
   allowedValues:
     type: array
+    nullable: true
     items:
       $ref: 'marcSpecificationItemValue.yaml'
 required:

--- a/src/test/java/org/folio/it/BaseIT.java
+++ b/src/test/java/org/folio/it/BaseIT.java
@@ -17,12 +17,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
 import lombok.SneakyThrows;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.folio.qm.ModQuickMarcApplication;
+import org.folio.qm.util.TenantContextUtils;
 import org.folio.rspec.domain.dto.SpecificationUpdatedEvent;
+import org.folio.spring.DefaultFolioExecutionContext;
 import org.folio.spring.FolioModuleMetadata;
 import org.folio.spring.integration.XOkapiHeaders;
 import org.folio.spring.testing.extension.EnableKafka;
@@ -97,6 +100,11 @@ public class BaseIT {
   @Test
   void contextLoads() {
     Assertions.assertTrue(true, "Context loaded successfully");
+  }
+
+  protected void runInTenantContext(Runnable runnable) {
+    var context = new DefaultFolioExecutionContext(metadata, Map.of(TENANT, List.of(TENANT_ID)));
+    TenantContextUtils.runInFolioContext(context, runnable);
   }
 
   protected ResultActions doGet(String uri) throws Exception {

--- a/src/test/java/org/folio/it/api/MarcSpecificationsIT.java
+++ b/src/test/java/org/folio/it/api/MarcSpecificationsIT.java
@@ -4,17 +4,36 @@ import static org.folio.support.utils.ApiTestUtils.marcSpecificationsByRecordTyp
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
 import lombok.extern.log4j.Log4j2;
 import org.folio.it.BaseIT;
 import org.folio.qm.domain.dto.MarcFormat;
+import org.folio.qm.domain.dto.MarcSpec;
+import org.folio.qm.domain.dto.MarcSpecSpec;
+import org.folio.qm.domain.dto.MarcSpecificationCondition;
+import org.folio.qm.domain.dto.MarcSpecificationItem;
+import org.folio.qm.domain.dto.MarcSpecificationItemValue;
+import org.folio.qm.domain.dto.MarcSpecificationType;
+import org.folio.qm.domain.dto.MarcSpecificationTypeIdentifiedBy;
+import org.folio.qm.domain.entity.MarcSpecification;
 import org.folio.qm.domain.entity.RecordType;
+import org.folio.qm.domain.repository.MarcSpecificationRepository;
 import org.folio.qm.util.ErrorUtils;
 import org.folio.spring.testing.type.IntegrationTest;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @Log4j2
 @IntegrationTest
 class MarcSpecificationsIT extends BaseIT {
+
+  private static final String CUSTOM_FIELD_TAG = "999";
+
+  @Autowired
+  private MarcSpecificationRepository marcSpecificationRepository;
 
   @Test
   void testGetMarcSpecificationsNotFound() throws Exception {
@@ -84,5 +103,85 @@ class MarcSpecificationsIT extends BaseIT {
     doGet(marcSpecificationsByRecordTypeAndFieldTag(RecordType.MARC_BIBLIOGRAPHIC.getValue(), "08"))
       .andExpect(status().isBadRequest())
       .andExpect(jsonPath("$.type").value(ErrorUtils.ErrorType.INTERNAL.getTypeCode()));
+  }
+
+  @Test
+  void testGetMarcSpecificationsSuccess_responseJsonFormat() throws Exception {
+    log.info("===== Verify GET MARC Specifications: Response JSON format (included/not-included fields) =====");
+
+    runInTenantContext(() -> marcSpecificationRepository.save(customBibliographicSpecification()));
+
+    doGet(marcSpecificationsByRecordTypeAndFieldTag(RecordType.MARC_BIBLIOGRAPHIC.getValue(), CUSTOM_FIELD_TAG))
+      .andExpect(status().isOk())
+      // required, non-null fields are present
+      .andExpect(jsonPath("$.tag").value(CUSTOM_FIELD_TAG))
+      .andExpect(jsonPath("$.format").value(MarcFormat.BIBLIOGRAPHIC.getValue()))
+      .andExpect(jsonPath("$.label").value("Custom field"))
+      .andExpect(jsonPath("$.required").value(true))
+      // `false` booleans are not treated as "empty" and must still be serialized
+      .andExpect(jsonPath("$.repeatable").value(false))
+      // `url` is null -> excluded from the response (NON_EMPTY global inclusion)
+      .andExpect(jsonPath("$.url").doesNotExist())
+      // item without allowedValues set -> field is absent (JsonNullable NON_ABSENT)
+      .andExpect(jsonPath("$.spec.types[0].items[0].code").value("noAllowedValues"))
+      .andExpect(jsonPath("$.spec.types[0].items[0].allowedValues").doesNotExist())
+      // item with allowedValues explicitly set -> field is present
+      .andExpect(jsonPath("$.spec.types[0].items[1].code").value("withAllowedValues"))
+      .andExpect(jsonPath("$.spec.types[0].items[1].allowedValues").isArray())
+      .andExpect(jsonPath("$.spec.types[0].items[1].allowedValues[0].code").value("a"))
+      // allowed value with null `name` -> excluded (NON_NULL on MarcSpecificationItemValue)
+      .andExpect(jsonPath("$.spec.types[0].items[1].allowedValues[0].name").doesNotExist());
+
+    // cleanup of custom spec
+    runInTenantContext(() -> marcSpecificationRepository
+      .findByRecordTypeAndFieldTag(RecordType.MARC_BIBLIOGRAPHIC, CUSTOM_FIELD_TAG)
+      .ifPresent(marcSpecificationRepository::delete));
+  }
+
+  private MarcSpecification customBibliographicSpecification() {
+    var type = new MarcSpecificationType()
+      .code("book")
+      .identifiedBy(new MarcSpecificationTypeIdentifiedBy()
+        .or(List.of(new MarcSpecificationCondition().tag("LDR").positions(Map.of()))))
+      .items(List.of(itemWithoutAllowedValues(), itemWithAllowedValues()));
+
+    var marcSpec = new MarcSpec()
+      .tag(CUSTOM_FIELD_TAG)
+      .format(MarcFormat.BIBLIOGRAPHIC)
+      .label("Custom field")
+      .url(null)
+      .repeatable(false)
+      .required(true)
+      .spec(new MarcSpecSpec().types(List.of(type)));
+
+    var entity = new MarcSpecification();
+    entity.setRecordType(RecordType.MARC_BIBLIOGRAPHIC);
+    entity.setFieldTag(CUSTOM_FIELD_TAG);
+    entity.setMarcSpec(marcSpec);
+    entity.setCreatedAt(Timestamp.from(Instant.parse("2026-05-07T10:00:00Z")));
+    return entity;
+  }
+
+  private MarcSpecificationItem itemWithoutAllowedValues() {
+    return new MarcSpecificationItem()
+      .code("noAllowedValues")
+      .name("Item without allowed values")
+      .order(0)
+      .position(0)
+      .length(1)
+      .isArray(false)
+      .readOnly(true);
+  }
+
+  private MarcSpecificationItem itemWithAllowedValues() {
+    return new MarcSpecificationItem()
+      .code("withAllowedValues")
+      .name("Item with allowed values")
+      .order(1)
+      .position(1)
+      .length(1)
+      .isArray(false)
+      .readOnly(true)
+      .allowedValues(List.of(new MarcSpecificationItemValue().code("a").name(null)));
   }
 }


### PR DESCRIPTION
### Purpose
Do not include nullable `allowedValues` field in specification response as UI has condition on existence. 

### Approach
_How does this change fulfill the purpose? Provide a high-level overview of the technical approach taken to address the problem._

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MODQM-519

### Learning and Resources (if applicable)
The issue is related to changes in openapi-generator: now it set `@JsonInclude(JsonInclude.Include.NON_NULL)` to all not required fields
